### PR TITLE
(SERVER-2254) Allow the CLI to read from puppetserver's config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gemspec
 
 gem 'pry'
 gem 'pry-byebug'
+gem 'hocon', '~> 1.2', require: false

--- a/lib/puppetserver/ca/config_utils.rb
+++ b/lib/puppetserver/ca/config_utils.rb
@@ -1,0 +1,11 @@
+module Puppetserver
+  module Ca
+    module ConfigUtils
+
+      def running_as_root?
+        !Gem.win_platform? && Process::UID.eid == 0
+      end
+
+    end
+  end
+end

--- a/lib/puppetserver/ca/puppet_config.rb
+++ b/lib/puppetserver/ca/puppet_config.rb
@@ -1,10 +1,13 @@
+require 'puppetserver/ca/config_utils'
 
 module Puppetserver
   module Ca
-    # Provides an interface for asking for Puppet[ Server] settings w/o loading
-    # either Puppet or Puppet Server. Includes a simple ini parser that will
-    # ignore Puppet's more complicated conventions.
+    # Provides an interface for asking for Puppet settings w/o loading
+    # Puppet. Includes a simple ini parser that will ignore Puppet's
+    # more complicated conventions.
     class PuppetConfig
+
+      include Puppetserver::Ca::ConfigUtils
 
       def self.parse(config_path = nil)
         instance = new(config_path)
@@ -119,15 +122,10 @@ module Puppetserver
         res
       end
 
-
      private
 
       def explicitly_given_config_file_or_default_config_exists?
         !@using_default_location || File.exist?(@config_path)
-      end
-
-      def running_as_root?
-        !Gem.win_platform? && Process::UID.eid == 0
       end
     end
   end

--- a/lib/puppetserver/ca/puppetserver_config.rb
+++ b/lib/puppetserver/ca/puppetserver_config.rb
@@ -1,0 +1,83 @@
+require 'hocon'
+require 'puppetserver/ca/config_utils'
+
+module Puppetserver
+  module Ca
+    # Provides an interface for querying Puppetserver settings w/o loading
+    # Puppetserver or any TK config service. Uses the ruby-hocon gem for parsing.
+    class PuppetserverConfig
+
+      include Puppetserver::Ca::ConfigUtils
+
+      def self.parse(config_path = nil)
+        instance = new(config_path)
+        instance.load
+
+        return instance
+      end
+
+      attr_reader :errors, :settings
+
+      def initialize(supplied_config_path = nil)
+        @using_default_location = !supplied_config_path
+        @config_path = supplied_config_path || "/etc/puppetlabs/puppetserver/conf.d/ca.conf"
+
+        @settings = nil
+        @errors = []
+      end
+
+      # Populate this config object with the CA-related settings
+      def load
+        if explicitly_given_config_file_or_default_config_exists?
+          begin
+            results = Hocon.load(@config_path)
+          rescue Hocon::ConfigError => e
+            errors << e.message
+          end
+        end
+
+        overrides = results || {}
+        @settings = supply_defaults(overrides).freeze
+      end
+
+      private
+
+      # Return the correct confdir. We check for being root on *nix,
+      # else the user path. We do not include a check for running
+      # as Adminstrator since non-development scenarios for Puppet Server
+      # on Windows are unsupported.
+      # Note that Puppet Server runs as the [pe-]puppet user but to
+      # start/stop it you must be root.
+      def user_specific_ca_dir
+        if running_as_root?
+          '/etc/puppetlabs/puppetserver/ca'
+        else
+          "#{ENV['HOME']}/.puppetlabs/etc/puppetserver/ca"
+        end
+      end
+
+      # Supply defaults for any CA settings not present in the config file
+      # @param [Hash] overrides setting names and values loaded from the config file,
+      #                         for overriding the defaults
+      # @return [Hash] CA-related settings
+      def supply_defaults(overrides = {})
+        ca_settings = overrides['certificate-authority'] || {}
+        settings = {}
+
+        cadir = settings[:cadir] = ca_settings.fetch('cadir', user_specific_ca_dir)
+
+        settings[:cacert] = ca_settings.fetch('cacert', "#{cadir}/ca_crt.pem")
+        settings[:cakey] = ca_settings.fetch('cakey', "#{cadir}/ca_key.pem")
+        settings[:cacrl] = ca_settings.fetch('cacrl', "#{cadir}/ca_crl.pem")
+        settings[:serial] = ca_settings.fetch('serial', "#{cadir}/serial")
+        settings[:cert_inventory] = ca_settings.fetch('cert-inventory', "#{cadir}/inventory.txt")
+
+        return settings
+      end
+
+      def explicitly_given_config_file_or_default_config_exists?
+        !@using_default_location || File.exist?(@config_path)
+      end
+    end
+  end
+end

--- a/spec/puppetserver/ca/puppetserver_config_spec.rb
+++ b/spec/puppetserver/ca/puppetserver_config_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'puppetserver/ca/puppetserver_config'
+
+RSpec.describe 'Puppetserver::Ca::PuppetserverConfig' do
+  it 'overrides defaults with settings from the config file' do
+    Dir.mktmpdir do |tmpdir|
+      puppetserver_conf = File.join(tmpdir, 'ca.conf')
+      File.open(puppetserver_conf, 'w') do |f|
+      f.puts(<<-CONF)
+      certificate-authority : {
+          cadir: "/etc/fake/path/ca"
+          cert-inventory: "/etc/fake/inventory.txt"
+      }
+      CONF
+      end
+
+      conf = Puppetserver::Ca::PuppetserverConfig.new(puppetserver_conf)
+      conf.load
+      expect(conf.settings[:cadir]).to eq('/etc/fake/path/ca')
+      expect(conf.settings[:cacert]).to eq('/etc/fake/path/ca/ca_crt.pem')
+      expect(conf.settings[:cert_inventory]).to eq('/etc/fake/inventory.txt')
+    end
+  end
+
+  it 'logs errors that occur during HOCON parsing' do
+    Dir.mktmpdir do |tmpdir|
+      puppetserver_conf = File.join(tmpdir, 'ca.conf')
+      File.open(puppetserver_conf, 'w') do |f|
+      f.puts(<<-CONF)
+      certificate-authority :
+          cadir: "/etc/fake/path/ca"
+          cert-inventory: "/etc/fake/inventory.txt"
+      }
+      CONF
+      end
+
+      conf = Puppetserver::Ca::PuppetserverConfig.new(puppetserver_conf)
+      conf.load
+      expect(conf.errors.size).to eq(1)
+      expect(conf.errors[0]).to match(/Expecting close brace/)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a PuppetserverConfig class responsible for parsing
CA-related settings out of Puppetserver's CA config file. This file is
written in HOCON, so this commit pulls in the ruby-hocon gem for parsing
the file.