### PR TITLE
(SERVER-2261) Rename puppetserver-ca's `setup` command to `import`

### DIFF
--- a/lib/puppetserver/ca/cli.rb
+++ b/lib/puppetserver/ca/cli.rb
@@ -1,6 +1,6 @@
 require 'optparse'
 require 'puppetserver/ca/version'
-require 'puppetserver/ca/setup_action'
+require 'puppetserver/ca/import_action'
 require 'puppetserver/ca/logger'
 
 module Puppetserver
@@ -13,7 +13,7 @@ Manage the Private Key Infrastructure for
 Puppet Server's built-in Certificate Authority
 BANNER
 
-      VALID_ACTIONS = {'setup' => SetupAction}
+      VALID_ACTIONS = {'import' => ImportAction}
 
       ACTION_LIST = "\nAvailable Actions:\n" +
         VALID_ACTIONS.map do |action, cls|

--- a/lib/puppetserver/ca/import_action.rb
+++ b/lib/puppetserver/ca/import_action.rb
@@ -6,13 +6,13 @@ require 'puppetserver/ca/puppet_config'
 
 module Puppetserver
   module Ca
-    class SetupAction
+    class ImportAction
 
-      SUMMARY = "Set up the CA's key, certs, and crls"
+      SUMMARY = "Import the CA's key, certs, and crls"
       BANNER = <<-BANNER
 Usage:
-  puppetserver ca setup [--help|--version]
-  puppetserver ca setup [--config PATH]
+  puppetserver ca import [--help|--version]
+  puppetserver ca import [--config PATH]
       --private-key PATH --cert-bundle PATH --crl-chain PATH
 
 Description:
@@ -175,7 +175,7 @@ BANNER
       def self.parser(parsed = {})
         OptionParser.new do |opts|
           opts.banner = BANNER
-          opts.on('--help', 'Display this setup specific help output') do |help|
+          opts.on('--help', 'Display this import specific help output') do |help|
             parsed['help'] = true
           end
           opts.on('--version', 'Output the version') do |v|

--- a/spec/puppetserver/ca/cli_spec.rb
+++ b/spec/puppetserver/ca/cli_spec.rb
@@ -21,18 +21,18 @@ RSpec.describe Puppetserver::Ca::Cli do
       /.*Usage: puppetserver ca <action> .*Display this general help output.*/m
   end
 
-  describe 'the setup action' do
+  describe 'the import action' do
     let(:usage) do
-      /.*Usage:.* puppetserver ca setup.*Display this setup specific help output.*/m
+      /.*Usage:.* puppetserver ca import.*Display this import specific help output.*/m
     end
 
     include_examples 'basic cli args',
-      'setup',
-      /.*Usage:.* puppetserver ca setup.*Display this setup specific help output.*/m
+      'import',
+      /.*Usage:.* puppetserver ca import.*Display this import specific help output.*/m
 
 
     it 'prints the help output & returns 1 if invalid flags are given' do
-      exit_code = Puppetserver::Ca::Cli.run(['setup', '--hello'], stdout, stderr)
+      exit_code = Puppetserver::Ca::Cli.run(['import', '--hello'], stdout, stderr)
       expect(stderr.string).to match(/Error.*--hello/m)
       expect(stderr.string).to match(usage)
       expect(exit_code).to be 1
@@ -41,7 +41,7 @@ RSpec.describe Puppetserver::Ca::Cli do
     it 'does not print the help output if called correctly' do
       Dir.mktmpdir do |tmpdir|
         with_files_in tmpdir do |bundle, key, chain, conf|
-          exit_code = Puppetserver::Ca::Cli.run(['setup',
+          exit_code = Puppetserver::Ca::Cli.run(['import',
                                                   '--cert-bundle', bundle,
                                                   '--private-key', key,
                                                   '--crl-chain', chain,
@@ -56,7 +56,7 @@ RSpec.describe Puppetserver::Ca::Cli do
     it 'accepts a --config flag' do
       Dir.mktmpdir do |tmpdir|
         with_files_in tmpdir do |bundle, key, chain, conf|
-          Puppetserver::Ca::Cli.run(['setup',
+          Puppetserver::Ca::Cli.run(['import',
                                       '--config', conf,
                                       '--cert-bundle', bundle,
                                       '--private-key', key,
@@ -71,7 +71,7 @@ RSpec.describe Puppetserver::Ca::Cli do
       it 'requires the --cert-bundle, --private-key, and --crl-chain options' do
         out1, err1 = StringIO.new, StringIO.new
         exit_code = Puppetserver::Ca::Cli.run(
-                      ['setup', '--private-key', 'foo', '--crl-chain', 'bar'],
+                      ['import', '--private-key', 'foo', '--crl-chain', 'bar'],
                       out1,
                       err1)
         expect(err1.string).to include('Missing required argument')
@@ -80,7 +80,7 @@ RSpec.describe Puppetserver::Ca::Cli do
 
         out2, err2 = StringIO.new, StringIO.new
         exit_code = Puppetserver::Ca::Cli.run(
-                      ['setup', '--cert-bundle', 'foo', '--crl-chain', 'bar'],
+                      ['import', '--cert-bundle', 'foo', '--crl-chain', 'bar'],
                       out2,
                       err2)
         expect(err2.string).to include('Missing required argument')
@@ -89,7 +89,7 @@ RSpec.describe Puppetserver::Ca::Cli do
 
         out3, err3 = StringIO.new, StringIO.new
         exit_code = Puppetserver::Ca::Cli.run(
-                      ['setup', '--private-key', 'foo', '--cert-bundle', 'bar'],
+                      ['import', '--private-key', 'foo', '--cert-bundle', 'bar'],
                       out3,
                       err3)
         expect(err3.string).to include('Missing required argument')
@@ -101,7 +101,7 @@ RSpec.describe Puppetserver::Ca::Cli do
         # All errors are surfaced from validations
         Dir.mktmpdir do |tmpdir|
           exit_code = Puppetserver::Ca::Cli.run(
-                        ['setup',
+                        ['import',
                          '--cert-bundle', File.join(tmpdir, 'cert_bundle.pem'),
                          '--private-key', File.join(tmpdir, 'private_key.pem'),
                          '--crl-chain', File.join(tmpdir, 'crl_chain.pem')],
@@ -122,7 +122,7 @@ RSpec.describe Puppetserver::Ca::Cli do
               f.puts '-----END CERTIFICATE-----'
             end
             exit_code = Puppetserver::Ca::Cli.run(
-                          ['setup',
+                          ['import',
                            '--cert-bundle', bundle,
                            '--private-key', key,
                            '--crl-chain', chain],
@@ -140,7 +140,7 @@ RSpec.describe Puppetserver::Ca::Cli do
           with_files_in tmpdir do |bundle, key, chain, conf|
             File.open(bundle, 'w') {|f| f.puts '' }
             exit_code = Puppetserver::Ca::Cli.run(
-                          ['setup',
+                          ['import',
                            '--cert-bundle', bundle,
                            '--private-key', key,
                            '--crl-chain', chain],
@@ -157,7 +157,7 @@ RSpec.describe Puppetserver::Ca::Cli do
           with_files_in tmpdir do |bundle, key, chain, conf|
             File.open(key, 'w') {|f| f.puts '' }
             exit_code = Puppetserver::Ca::Cli.run(
-                          ['setup',
+                          ['import',
                            '--cert-bundle', bundle,
                            '--private-key', key,
                            '--crl-chain', chain],
@@ -174,7 +174,7 @@ RSpec.describe Puppetserver::Ca::Cli do
           with_files_in tmpdir do |bundle, key, chain, conf|
             File.open(key, 'w') {|f| f.puts OpenSSL::PKey::RSA.new(1024).to_pem }
             exit_code = Puppetserver::Ca::Cli.run(
-                          ['setup',
+                          ['import',
                            '--cert-bundle', bundle,
                            '--private-key', key,
                            '--crl-chain', chain],
@@ -195,7 +195,7 @@ RSpec.describe Puppetserver::Ca::Cli do
               f.puts '-----END X509 CRL-----'
             end
             exit_code = Puppetserver::Ca::Cli.run(
-                          ['setup',
+                          ['import',
                            '--cert-bundle', bundle,
                            '--private-key', key,
                            '--crl-chain', chain],
@@ -213,7 +213,7 @@ RSpec.describe Puppetserver::Ca::Cli do
           with_files_in tmpdir do |bundle, key, chain, conf|
             File.open(chain, 'w') {|f| f.puts '' }
             exit_code = Puppetserver::Ca::Cli.run(
-                          ['setup',
+                          ['import',
                            '--cert-bundle', bundle,
                            '--private-key', key,
                            '--crl-chain', chain],
@@ -240,7 +240,7 @@ RSpec.describe Puppetserver::Ca::Cli do
             end
 
             exit_code = Puppetserver::Ca::Cli.run(
-                          ['setup',
+                          ['import',
                            '--cert-bundle', bundle,
                            '--private-key', key,
                            '--crl-chain', chain],
@@ -282,7 +282,7 @@ RSpec.describe Puppetserver::Ca::Cli do
             f.puts root_crl.to_pem
           end
 
-          exit_code = Puppetserver::Ca::Cli.run(['setup',
+          exit_code = Puppetserver::Ca::Cli.run(['import',
                                                   '--private-key', key_file,
                                                   '--cert-bundle', bundle_file,
                                                   '--crl-chain', chain_file],
@@ -297,7 +297,7 @@ RSpec.describe Puppetserver::Ca::Cli do
         Dir.mktmpdir do |tmpdir|
           with_files_in tmpdir do |bundle, key, chain, conf|
             FileUtils.rm conf
-            exit_code = Puppetserver::Ca::Cli.run(['setup',
+            exit_code = Puppetserver::Ca::Cli.run(['import',
                                                     '--config', conf,
                                                     '--cert-bundle', bundle,
                                                     '--private-key', key,
@@ -319,7 +319,7 @@ RSpec.describe Puppetserver::Ca::Cli do
                 cadir = #{tmpdir}/ca
             INI
           end
-          exit_code = Puppetserver::Ca::Cli.run(['setup',
+          exit_code = Puppetserver::Ca::Cli.run(['import',
                                                   '--cert-bundle', bundle,
                                                   '--private-key', key,
                                                   '--crl-chain', chain,


### PR DESCRIPTION
This commit renames the `setup` subcommand to `import`, to better
differentiate it from `generate`, which also sets up a CA.