### PR TITLE
(SERVER-1714) Add sign action

### DIFF
--- a/lib/puppetserver/ca/cli.rb
+++ b/lib/puppetserver/ca/cli.rb
@@ -4,6 +4,8 @@ require 'puppetserver/ca/logger'
 require 'puppetserver/ca/import_action'
 require 'puppetserver/ca/generate_action'
 require 'puppetserver/ca/revoke_action'
+require 'puppetserver/ca/sign_action'
+require 'puppetserver/ca/utils'
 
 module Puppetserver
   module Ca
@@ -18,7 +20,8 @@ BANNER
       VALID_ACTIONS = {
         'import'   => ImportAction,
         'generate' => GenerateAction,
-        'revoke'   => RevokeAction
+        'revoke'   => RevokeAction,
+        'sign'     => SignAction
       }
 
       ACTION_LIST = "\nAvailable Actions:\n" +
@@ -94,19 +97,9 @@ BANNER
 
         end
 
-        unparsed, nonopts = [], []
+        all,_,_,_ = Utils.parse_without_raising(general_parser, inputs)
 
-        begin
-          general_parser.order!(inputs) do |nonopt|
-            nonopts << nonopt
-          end
-        rescue OptionParser::InvalidOption => e
-          unparsed += e.args
-          unparsed << inputs.shift unless inputs.first =~ /^-{1,2}/
-          retry
-        end
-
-        return general_parser, parsed, nonopts + unparsed
+        return general_parser, parsed, all
       end
     end
   end

--- a/lib/puppetserver/ca/sign_action.rb
+++ b/lib/puppetserver/ca/sign_action.rb
@@ -1,0 +1,181 @@
+require 'puppetserver/ca/utils'
+require 'puppetserver/utils/http_utilities'
+require 'puppetserver/utils/file_utilities'
+require 'puppetserver/ca/puppet_config'
+require 'optparse'
+require 'openssl'
+require 'net/https'
+require 'json'
+
+module Puppetserver
+  module Ca
+    class SignAction
+
+      include Puppetserver::Utils
+
+      SUMMARY = 'Sign a given certificate'
+      BANNER = <<-BANNER
+Usage:
+  puppetserver ca sign [--help|--version]
+  puppetserver ca sign [--config] --certname CERTNAME[,CERTNAME]
+  puppetserver ca sign  --all
+
+Description:
+Given a comma-separated list of valid certnames, instructs the CA to sign each cert.
+
+Options:
+      BANNER
+      BODY = JSON.dump({desired_state: 'signed'})
+
+      def self.parser(parsed = {})
+        OptionParser.new do |opts|
+          opts.banner = BANNER
+          opts.on('--certname x,y,z', Array, 'the name(s) of the cert(s) to be signed') do |cert|
+            parsed['certname'] = cert
+          end
+          opts.on('--config PUPPET.CONF', 'Custom path to Puppet\'s config file') do |conf|
+            parsed['config'] = conf
+          end
+          opts.on('--help', 'Display this command specific help output') do |help|
+            parsed['help'] = true
+          end
+          opts.on('--version', 'Output the version') do |v|
+            parsed['version'] = true
+          end
+          opts.on('--all', 'Operate on all certnames') do |a|
+            parsed['all'] = true
+          end
+        end
+      end
+
+      def initialize(logger)
+        @logger = logger
+      end
+
+      def run(input)
+        config = input['config']
+
+        if config
+          errors = FileUtilities.validate_file_paths(config)
+          return 1 if Utils.handle_errors(@logger, errors)
+        end
+
+        puppet = PuppetConfig.parse(config)
+        return 1 if Utils.handle_errors(@logger, puppet.errors)
+
+        if input['all']
+          requested_certnames = get_all_pending_certs(puppet.settings)
+          if requested_certnames.nil?
+            return 1
+          end
+        else
+          requested_certnames = input['certname']
+        end
+
+        success = sign_requested_certs(requested_certnames, puppet.settings)
+        return success ? 0 : 1
+      end
+
+      def get_certificate_statuses(settings)
+        url = HttpUtilities.make_ca_url(settings[:ca_server], settings[:ca_port],
+                                        'certificate_statuses', 'any_key')
+        HttpUtilities.with_connection(url, settings) do |connection|
+          connection.get(url)
+        end
+      end
+
+      def sign_certs(certnames,settings)
+        results = { }
+        url = HttpUtilities.make_ca_url(settings[:ca_server], settings[:ca_port],
+                                        'certificate_status')
+        HttpUtilities.with_connection(url, settings) do |connection|
+          certnames.each do |certname|
+            url.resource_name = certname
+            results[certname] = connection.put(BODY, url)
+          end
+        end
+        return results
+      end
+
+      def get_all_certs(settings)
+        result = get_certificate_statuses(settings)
+
+        unless result.is_a? Net::HTTPOK
+            @logger.err 'Error:'
+            @logger.err "    #{result.inspect}"
+            return nil
+        end
+        return result
+      end
+
+      def select_pending_certs(get_result)
+        requested_certnames = JSON.parse(get_result).select{|e| e["state"] == "requested"}.map{|e| e["name"]}
+
+        if requested_certnames.empty?
+          @logger.err 'Error:'
+          @logger.err "    No waiting certificate requests to sign"
+          return nil
+        end
+
+        return requested_certnames
+      end
+
+      def get_all_pending_certs(settings)
+        result = get_all_certs(settings)
+        if result
+          select_pending_certs(result.body)
+        end
+      end
+
+      def sign_requested_certs(certnames,settings)
+        success = true
+        results = sign_certs(certnames, settings)
+        results.each do |certname, result|
+          case result.code
+          when '204'
+            @logger.inform "Signed certificate for #{certname}"
+          when '404'
+            @logger.err 'Error:'
+            @logger.err "    Could not find certificate for #{certname}"
+            success = false
+          else
+            @logger.err 'Error:'
+            @logger.err "    When download requested for #{result.inspect}"
+            @logger.err "    code: #{result.code}"
+            @logger.err "    body: #{result.body_to_s}" if result.body
+            success = false
+          end
+        end
+        return success
+      end
+
+      def check_flag_usage(results)
+        if results['certname'] && results['all']
+          '--all and --certname cannot be used together'
+        elsif !results['certname'] && !results['all']
+          'No arguments given'
+        elsif results['certname'] && results['certname'].include?('--all')
+          'Cannot use --all with --certname. If you actually have a certificate request ' +
+                          'for a certifcate named --all, you need to use the HTTP API.'
+        end
+      end
+
+      def parse(args)
+        results = {}
+        parser = self.class.parser(results)
+
+        errors = Utils.parse_with_errors(parser, args)
+
+        if check_flag_usage(results)
+          errors << check_flag_usage(results)
+        end
+
+        errors_were_handled = Utils.handle_errors(@logger, errors, parser.help)
+
+        exit_code = errors_were_handled ? 1 : nil
+
+        return results, exit_code
+      end
+    end
+  end
+end

--- a/lib/puppetserver/utils/file_utilities.rb
+++ b/lib/puppetserver/utils/file_utilities.rb
@@ -1,6 +1,5 @@
 require 'fileutils'
 require 'etc'
-require 'pry'
 
 module Puppetserver
   module Utils

--- a/lib/puppetserver/utils/http_utilities.rb
+++ b/lib/puppetserver/utils/http_utilities.rb
@@ -52,6 +52,13 @@ module Puppetserver
 
           Result.new(result.code, result.body)
         end
+
+        def get(url_overide = nil)
+          url = url_overide || @url
+
+          request = Net::HTTP::Get.new(url.to_uri)
+          result = @conn.request(request)
+        end
       end
 
       # Just provide the bits of Net::HTTPResponse we care about

--- a/spec/puppetserver/ca/cli_spec.rb
+++ b/spec/puppetserver/ca/cli_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Puppetserver::Ca::Cli do
       /.*Usage:.* puppetserver ca revoke.*instructs the CA to revoke.*/m
   end
 
+  describe 'the sign action' do
+    let (:usage) do
+      /.*Usage:.* puppetserver ca sign.*Display this command specific help output.*/m
+    end
+
+    include_examples 'basic cli args',
+      'sign',
+      /.*Usage.* puppetserver ca sign.*Display this command specific help output.*/m
+  end
+
   describe 'the import action' do
     let(:usage) do
       /.*Usage:.* puppetserver ca import.*Display this import specific help output.*/m

--- a/spec/puppetserver/ca/sign_action_spec.rb
+++ b/spec/puppetserver/ca/sign_action_spec.rb
@@ -1,0 +1,89 @@
+require 'puppetserver/ca/sign_action'
+require 'puppetserver/ca/cli'
+require 'puppetserver/ca/logger'
+
+RSpec.describe 'Puppetserver::Ca::SignAction' do
+  let(:err)    { StringIO.new }
+  let(:out) { StringIO.new }
+  let(:logger) { Puppetserver::Ca::Logger.new(:info, out, err) }
+  let(:action) { Puppetserver::Ca::SignAction.new(logger) }
+
+  describe 'validation' do
+    it 'does not expect an argument' do
+      _, exit_code = action.parse(['--all', 'foo'])
+      expect(err.string).to match(/Error:.*Unknown input.*foo/m)
+      expect(exit_code).to eq(1)
+    end
+
+    it 'does not allow --all with a valid certname call' do
+      _, exit_code = action.parse(['--certname', 'foo', '--all'])
+      expect(err.string).to include('--all and --certname cannot be used together')
+      expect(exit_code).to eq(1)
+    end
+
+    it 'errors without any arguments' do
+      _, exit_code = action.parse([])
+      expect(err.string).to include('No arguments given')
+      expect(exit_code).to eq(1)
+    end
+
+    it 'errors without a certname' do
+      _, exit_code = action.parse(['--certname'])
+      expect(err.string).to match(/Error:.*Missing argument to flag/m)
+      expect(exit_code).to eq(1)
+    end
+
+    it 'does not allow --certname and --all' do
+      _, exit_code = action.parse(['--certname', '--all'])
+      expect(err.string).to match(/Cannot use --all.*HTTP API/)
+      expect(exit_code).to eq(1)
+    end
+
+    it 'works with a single cert' do
+      results, exit_code = action.parse(['--certname', 'foo'])
+      expect(results['certname']).to eq(['foo'])
+      expect(exit_code).to eq(nil)
+    end
+
+    it 'works with a comma separated list of certs' do
+      results, exit_code = action.parse(['--certname', 'foo,bar,baz'])
+      expect(results['certname']).to eq(['foo','bar','baz'])
+      expect(exit_code).to eq(nil)
+    end
+  end
+
+  describe 'error handling' do
+    let(:response)  { Struct.new(:code, :body) }
+    let(:success)   { response.new('204', nil) }
+    let(:not_found) { response.new('404', 'Not Found') }
+    let(:empty)     { response.new('404', '[]') }
+
+    it 'logs and exits with zero with successful PUT' do
+      allow(action).to receive(:sign_certs).and_return({'foo' => success})
+      exit_code = action.run({'certname' => ['foo']})
+      expect(exit_code).to eq(0)
+      expect(out.string).to include('Signed certificate for foo')
+    end
+
+    it 'fails when PUT request errors' do
+      allow(action).to receive(:get_certificate_statuses).and_return(not_found)
+      exit_code = action.run({'all' => true})
+      expect(exit_code).to eq(1)
+    end
+
+    it 'fails when no pending certs' do
+      allow(action).to receive(:get_all_certs).and_return(empty)
+      exit_code = action.run({'all' => true})
+      expect(exit_code).to eq(1)
+      expect(err.string).to include('No waiting certificate requests to sign')
+    end
+
+    it 'continues signing certs after failed request' do
+      allow(action).to receive(:sign_certs).and_return({'foo' => success, 'bar' => not_found, 'baz' => success})
+      exit_code = action.run({'certname' => ['foo','bar','baz']})
+      expect(exit_code).to eq(1)
+      expect(out.string).to match(/Signed certificate for foo.*Signed certificate for baz/m)
+      expect(err.string).to include('Could not find certificate for bar')
+    end
+  end
+end


### PR DESCRIPTION
This is still a work in progress, but I thought it might be nice to get some feedback. The main chunk of work is the logic in ``puppetserver/ca/sign_action.rb`` differentiating between use with and without the ``--all`` flag. I'm not sure all of the parsing logic stands, but I've tested it manually in the irb and I can confirm that it's signing certs. The rest is just getting it pretty/efficient, and I'm starting to write the spec.