### PR TITLE
(SERVER-2259) Add clean action

### DIFF
--- a/lib/puppetserver/ca/clean_action.rb
+++ b/lib/puppetserver/ca/clean_action.rb
@@ -1,0 +1,155 @@
+require 'puppetserver/ca/utils'
+require 'puppetserver/utils/http_utilities'
+require 'puppetserver/utils/file_utilities'
+require 'puppetserver/ca/puppet_config'
+require 'puppetserver/ca/revoke_action'
+
+require 'optparse'
+require 'json'
+
+module Puppetserver
+  module Ca
+    class CleanAction
+
+      include Puppetserver::Utils
+
+      CERTNAME_BLACKLIST = %w{--all --config}
+
+      SUMMARY = 'Clean files from the CA for certificate(s)'
+      BANNER = <<-BANNER
+Usage:
+  puppetserver ca clean [--help|--version]
+  puppetserver ca clean [--config] --certname CERTNAME[,ADDLCERTNAME]
+
+Description:
+Given one or more valid certnames, instructs the CA to revoke certificates
+matching the given certnames if they exist, and then remove files pertaining
+to them (keys, cert, and certificate request) over HTTPS using the local
+agent's PKI
+
+Options:
+BANNER
+
+      def self.parser(parsed = {})
+        parsed['certnames'] = []
+        OptionParser.new do |o|
+          o.banner = BANNER
+          o.on('--certname foo,bar', Array,
+               'One or more comma separated certnames') do |certs|
+            parsed['certnames'] += certs
+          end
+          o.on('--config PUPPET.CONF', 'Custom path to puppet.conf') do |conf|
+            parsed['config'] = conf
+          end
+          o.on('--help', 'Displays this clean specific help output') do |help|
+            parsed['help'] = help
+          end
+        end
+      end
+
+      def initialize(logger)
+        @logger = logger
+      end
+
+      def parse(args)
+        results = {}
+        parser = self.class.parser(results)
+
+        errors = Utils.parse_with_errors(parser, args)
+
+        results['certnames'].each do |certname|
+          if CERTNAME_BLACKLIST.include?(certname)
+            errors << "    Cannot manage cert named `#{certname}` from " +
+                      "the CLI, if needed use the HTTP API directly"
+          end
+        end
+
+        if results['certnames'].empty?
+          errors << '  At least one certname is required to clean'
+        end
+
+        errors_were_handled = Utils.handle_errors(@logger, errors, parser.help)
+
+        exit_code = errors_were_handled ? 1 : nil
+
+        return results, exit_code
+      end
+
+      def run(args)
+        certnames = args['certnames']
+        config = args['config']
+
+        if config
+          errors = FileUtilities.validate_file_paths(config)
+          return 1 if Utils.handle_errors(@logger, errors)
+        end
+
+        puppet = PuppetConfig.parse(config)
+        return 1 if Utils.handle_errors(@logger, puppet.errors)
+
+        passed = clean_certs(certnames, puppet.settings)
+
+        return passed ? 0 : 1
+      end
+
+      def clean_certs(certnames, settings)
+        url = HttpUtilities.make_ca_url(settings[:ca_server],
+                       settings[:ca_port],
+                       'certificate_status')
+
+        results = HttpUtilities.with_connection(url, settings) do |connection|
+          certnames.map do |certname|
+            url.resource_name = certname
+            revoke_result = connection.put(RevokeAction::REQUEST_BODY, url)
+            revoked = check_revocation(revoke_result, certname)
+
+            cleaned = nil
+            unless revoked == :error
+              clean_result = connection.delete(url)
+              cleaned = check_result(clean_result, certname)
+            end
+
+            cleaned == :success && [:success, :not_found].include?(revoked)
+          end
+        end
+
+        return results.all?
+      end
+
+      # possibly logs the action, always returns a status symbol 👑
+      def check_revocation(result, certname)
+        case result.code
+        when '200', '204'
+          @logger.inform "Revoked certificate for #{certname}"
+          return :success
+        when '404'
+          return :not_found
+        else
+          @logger.err 'Error:'
+          @logger.err "    Failed revoking certificate for #{certname}"
+          @logger.err "    Received code: #{result.code}, body: #{result.body}"
+          return :error
+        end
+      end
+
+      # logs the action and returns a status symbol 👑
+      def check_result(result, certname)
+        case result.code
+        when '200', '204'
+          @logger.inform "Cleaned files related to #{certname}"
+          return :success
+        when '404'
+          @logger.err 'Error:'
+          @logger.err "    Could not find files for #{certname}"
+          return :not_found
+        else
+          @logger.err 'Error:'
+          @logger.err "    When cleaning #{certname} received:"
+          @logger.err "      code: #{result.code}"
+          @logger.err "      body: #{result.body.to_s}" if result.body
+          return :error
+        end
+      end
+    end
+  end
+end

--- a/lib/puppetserver/ca/cli.rb
+++ b/lib/puppetserver/ca/cli.rb
@@ -1,6 +1,7 @@
 require 'optparse'
 require 'puppetserver/ca/version'
 require 'puppetserver/ca/logger'
+require 'puppetserver/ca/clean_action'
 require 'puppetserver/ca/import_action'
 require 'puppetserver/ca/generate_action'
 require 'puppetserver/ca/revoke_action'
@@ -18,6 +19,7 @@ Puppet Server's built-in Certificate Authority
 BANNER
 
       VALID_ACTIONS = {
+        'clean'    => CleanAction,
         'import'   => ImportAction,
         'generate' => GenerateAction,
         'revoke'   => RevokeAction,

--- a/lib/puppetserver/utils/http_utilities.rb
+++ b/lib/puppetserver/utils/http_utilities.rb
@@ -59,6 +59,14 @@ module Puppetserver
           request = Net::HTTP::Get.new(url.to_uri)
           result = @conn.request(request)
         end
+
+        def delete(url_override = nil)
+          url = url_override || @url
+
+          result = @conn.request(Net::HTTP::Delete.new(url.to_uri, HEADERS))
+
+          Result.new(result.code, result.body)
+        end
       end
 
       # Just provide the bits of Net::HTTPResponse we care about

--- a/spec/puppetserver/ca/clean_action_spec.rb
+++ b/spec/puppetserver/ca/clean_action_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+require 'puppetserver/ca/clean_action'
+require 'puppetserver/ca/logger'
+require 'puppetserver/utils/http_utilities'
+
+RSpec.describe Puppetserver::Ca::CleanAction do
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+  let(:logger) { Puppetserver::Ca::Logger.new(:info, stdout, stderr) }
+
+  subject { Puppetserver::Ca::CleanAction.new(logger) }
+
+  describe 'flags' do
+    it 'takes a single certname' do
+      result, maybe_code = subject.parse(['--certname', 'foo.example.com'])
+      expect(maybe_code).to eq(nil)
+      expect(result['certnames']).to eq(['foo.example.com'])
+    end
+
+    it 'takes a comma separated list of certnames' do
+      result, maybe_code = subject.parse(['--certname', 'foo,bar'])
+      expect(maybe_code).to eq(nil)
+      expect(result['certnames']).to eq(['foo', 'bar'])
+    end
+
+    it 'takes a custom puppet.conf location' do
+      result, maybe_code = subject.parse(['--certname', 'foo',
+                                          '--config', '/dev/tcp/example.com'])
+      expect(maybe_code).to be(nil)
+      expect(result['config']).to eq('/dev/tcp/example.com')
+    end
+  end
+
+  describe 'validation' do
+    it 'requires at least one certname' do
+      result, code = subject.parse([])
+      expect(code).to eq(1)
+      expect(stderr.string).to include('one certname is required')
+    end
+
+    it 'cannot clean certs with the names of flags' do
+      result, code = subject.parse(['--certname', '--config'])
+      expect(code).to eq(1)
+      expect(stderr.string).to include('Cannot manage cert named `--config`')
+      expect(result['certnames']).to eq(['--config'])
+    end
+  end
+
+  describe 'clean' do
+    Result = Struct.new(:code, :body)
+
+    let(:success) { Result.new('204', '') }
+    let(:not_found) { Result.new('404', 'Not Found') }
+    let(:error) { Result.new('500', 'Internal Server Error') }
+    let(:connection) { double }
+
+    before do
+      allow(Puppetserver::Utils::HttpUtilities).
+        to receive(:with_connection).and_yield(connection)
+    end
+
+    it 'logs success and returns zero if revoked and cleaned' do
+      allow(connection).to receive(:put).and_return(success)
+      allow(connection).to receive(:delete).and_return(success)
+
+      code = subject.run({'certnames' => ['foo']})
+      expect(code).to eq(0)
+      expect(stdout.string).to match(/Revoked.*foo/)
+      expect(stdout.string).to include('Cleaned files related to foo')
+      expect(stderr.string).to be_empty
+    end
+
+    it 'logs success and returns zero if cleaned but already revoked' do
+      allow(connection).to receive(:put).and_return(not_found)
+      allow(connection).to receive(:delete).and_return(success)
+
+      code = subject.run({'certnames' => ['foo']})
+      expect(code).to eq(0)
+      expect(stdout.string).to include('Cleaned files related to foo')
+      expect(stderr.string).to be_empty
+    end
+
+    it 'fails and does not attempt to clean if revocation fails' do
+      allow(connection).to receive(:put).and_return(error)
+      expect(connection).not_to receive(:delete)
+
+      code = subject.run({'certnames' => ['foo']})
+      expect(code).to eq(1)
+      expect(stdout.string).to be_empty
+      expect(stderr.string).to include('Failed revoking certificate')
+    end
+
+    it 'logs an error and returns 1 if any could not be cleaned' do
+      not_found = Result.new('404', 'Not Found')
+      allow(connection).to receive(:put).and_return(success)
+      allow(connection).to receive(:delete).and_return(not_found, success)
+
+      code = subject.run({'certnames' => ['foo', 'bar']})
+      expect(code).to eq(1)
+      expect(stdout.string).to include('Cleaned files related to bar')
+      expect(stderr.string).to match(/Error.*not find files for foo/m)
+    end
+
+    it 'prints an error and returns 1 if an unknown error occurs' do
+      error = Result.new('500', 'Internal Server Error')
+      allow(connection).to receive(:put).and_return(success)
+      allow(connection).to receive(:delete).and_return(error, success)
+
+      code = subject.run({'certnames' => ['foo', 'bar']})
+      expect(code).to eq(1)
+      expect(stdout.string).to include('Cleaned files related to bar')
+      expect(stderr.string).
+        to match(/Error.*cleaning foo.*code: 500.*body: Internal Server Error/m)
+    end
+  end
+end


### PR DESCRIPTION
This provides a clean action. The inputs (and their validation) is the same as the `revoke` action. The actual action is a superset of revocation (send a PUT to revoke and then a DELETE to clean up after ourselves). Consequently a lot of this is directly boilerplate from revoke.

I assume we might want to create a CA object that we can delegate the shared behaviors and validation to? Thought I'd run doing that by folks (in this or another PR).

At a minimum this needs a rebase, but I'ld love to get folks feedback on the approach/see if I'm missing anything.