### PR TITLE
(SERVER-2269) Allow specifying subject alt names when generating the CA

### DIFF
--- a/lib/puppetserver/ca/generate_action.rb
+++ b/lib/puppetserver/ca/generate_action.rb
@@ -188,6 +188,12 @@ BANNER
         cert
       end
 
+      # Given any alt names specified on the command line and any loaded from
+      # settings, choose the names with the highest precedence and process them.
+      # Precedence:
+      # 1) Specified on the CLI
+      # 2) Specified in settings
+      # 3) Defaults
       def choose_alt_names(cli_alt_names, settings_alt_names)
         if !cli_alt_names.empty?
           sans = cli_alt_names

--- a/lib/puppetserver/ca/puppet_config.rb
+++ b/lib/puppetserver/ca/puppet_config.rb
@@ -129,6 +129,8 @@ module Puppetserver
         settings[:publickeydir] =   overrides.fetch(:publickeydir, '$ssldir/public_keys')
         settings[:certificate_revocation] = parse_crl_usage(overrides.fetch(:certificate_revocation, 'true'))
 
+        settings[:subject_alt_names] = overrides.fetch(:dns_alt_names, '')
+
         settings.each_pair do |key, value|
           next unless value.is_a? String
 

--- a/spec/puppetserver/ca/cli_spec.rb
+++ b/spec/puppetserver/ca/cli_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe Puppetserver::Ca::Cli do
       /.*Usage.* puppetserver ca sign.*Display this command specific help output.*/m
   end
 
+  describe 'the generate action' do
+    let(:usage) { /.*Usage:.* puppetserver ca generate.*Display this generate specific help output.*/m }
+
+    include_examples 'basic cli args',
+      'generate',
+      /.*Usage:.* puppetserver ca generate.*Display this generate specific help output.*/m
+  end
+
   describe 'the import action' do
     let(:usage) do
       /.*Usage:.* puppetserver ca import.*Display this import specific help output.*/m
@@ -53,7 +61,6 @@ RSpec.describe Puppetserver::Ca::Cli do
       expect(stderr.string).to match(usage)
       expect(exit_code).to be 1
     end
-
 
     it 'prints the help output & returns 1 if no input is given' do
       exit_code = Puppetserver::Ca::Cli.run(['import'], stdout, stderr)
@@ -371,45 +378,6 @@ RSpec.describe Puppetserver::Ca::Cli do
       expect(stderr.string).to match(/Error.*--hello/m)
       expect(stderr.string).to match(usage)
       expect(exit_code).to eq(1)
-    end
-  end
-
-  describe 'the generate action' do
-    let(:usage) { /.*Usage:.* puppetserver ca generate.*Display this generate specific help output.*/m }
-
-    include_examples 'basic cli args',
-      'generate',
-      /.*Usage:.* puppetserver ca generate.*Display this generate specific help output.*/m
-
-    it 'prints the help output & returns 1 if invalid flags are given' do
-      exit_code = Puppetserver::Ca::Cli.run(['generate', '--hello'], stdout, stderr)
-      expect(stderr.string).to match(/Error.*--hello/m)
-      expect(stderr.string).to match(usage)
-      expect(exit_code).to eq(1)
-    end
-
-    it 'does not print the help output if called correctly' do
-      Dir.mktmpdir do |tmpdir|
-        with_temp_dirs tmpdir do |conf|
-          exit_code = Puppetserver::Ca::Cli.run(['generate', '--config', conf], stdout, stderr)
-          expect(stderr.string).to be_empty
-          expect(stdout.string.strip).to eq("Generation succeeded. Find your files in #{tmpdir}/ca")
-          expect(exit_code).to eq(0)
-        end
-      end
-    end
-
-    it 'generates a bundle ca_crt file, ca_key, int_key, and ca_crl file' do
-      Dir.mktmpdir do |tmpdir|
-        with_temp_dirs tmpdir do |conf|
-          exit_code = Puppetserver::Ca::Cli.run(['generate', '--config', conf], stdout, stderr)
-          expect(exit_code).to eq(0)
-          expect(File.exist?(File.join(tmpdir, 'ca', 'ca_crt.pem'))).to be true
-          expect(File.exist?(File.join(tmpdir, 'ca', 'ca_key.pem'))).to be true
-          expect(File.exist?(File.join(tmpdir, 'ca', 'root_key.pem'))).to be true
-          expect(File.exist?(File.join(tmpdir, 'ca', 'ca_crl.pem'))).to be true
-        end
-      end
     end
   end
 end

--- a/spec/puppetserver/ca/generate_action_spec.rb
+++ b/spec/puppetserver/ca/generate_action_spec.rb
@@ -5,6 +5,8 @@ require 'shared_examples/cli_parsing'
 require 'puppetserver/ca/cli'
 require 'puppetserver/ca/generate_action'
 require 'puppetserver/ca/logger'
+require 'puppetserver/utils/signing_digest'
+require 'puppetserver/ca/host'
 
 RSpec.describe Puppetserver::Ca::GenerateAction do
   let(:stderr) { StringIO.new }
@@ -17,7 +19,7 @@ RSpec.describe Puppetserver::Ca::GenerateAction do
 
   it 'generates a bundle ca_crt file, ca_key, int_key, and ca_crl file' do
     Dir.mktmpdir do |tmpdir|
-      with_temp_cadir tmpdir do |conf|
+      with_temp_dirs tmpdir do |conf|
         exit_code = subject.run({ 'config' => conf, 'subject_alt_names' => '' })
         expect(exit_code).to eq(0)
         expect(File.exist?(File.join(tmpdir, 'ca', 'ca_crt.pem'))).to be true
@@ -46,13 +48,14 @@ RSpec.describe Puppetserver::Ca::GenerateAction do
     end
 
     it 'adds subject alt names to the intermediate CA cert' do
-      digest = subject.default_signing_digest
+      digest = Puppetserver::Utils::SigningDigest.new.digest
+      host = Puppetserver::Ca::Host.new(digest)
       valid_until = Time.now + 1000
 
-      root_key = subject.create_private_key(4096)
+      root_key = host.create_private_key(4096)
       root_cert = subject.self_signed_ca(root_key, "root", valid_until, digest)
-      int_key = subject.create_private_key(4096)
-      int_csr = subject.create_csr(int_key, "int_ca", digest)
+      int_key = host.create_private_key(4096)
+      int_csr = host.create_csr("int_ca", int_key)
       int_cert = subject.sign_intermediate(root_key, root_cert, int_csr, valid_until, digest, "DNS:bar.net, IP:123.123.0.1")
       expect(int_cert.extensions[4].to_s).to eq("subjectAltName = DNS:bar.net, IP Address:123.123.0.1")
     end

--- a/spec/puppetserver/ca/generate_action_spec.rb
+++ b/spec/puppetserver/ca/generate_action_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'utils/ssl'
+require 'shared_examples/cli_parsing'
+
+require 'puppetserver/ca/cli'
+require 'puppetserver/ca/generate_action'
+require 'puppetserver/ca/logger'
+
+RSpec.describe Puppetserver::Ca::GenerateAction do
+  let(:stderr) { StringIO.new }
+  let(:stdout) { StringIO.new }
+  let(:logger) { Puppetserver::Ca::Logger.new(:info, STDOUT, stderr) }
+
+  subject { Puppetserver::Ca::GenerateAction.new(logger) }
+
+  include Utils::SSL
+
+  it 'generates a bundle ca_crt file, ca_key, int_key, and ca_crl file' do
+    Dir.mktmpdir do |tmpdir|
+      with_temp_cadir tmpdir do |conf|
+        exit_code = subject.run({ 'config' => conf, 'subject_alt_names' => '' })
+        expect(exit_code).to eq(0)
+        expect(File.exist?(File.join(tmpdir, 'ca', 'ca_crt.pem'))).to be true
+        expect(File.exist?(File.join(tmpdir, 'ca', 'ca_key.pem'))).to be true
+        expect(File.exist?(File.join(tmpdir, 'ca', 'root_key.pem'))).to be true
+        expect(File.exist?(File.join(tmpdir, 'ca', 'ca_crl.pem'))).to be true
+      end
+    end
+  end
+
+  describe 'subject alternative names' do
+    it 'accepts unprefixed alt names' do
+      result, maybe_code = subject.parse(['--subject-alt-names', 'foo.com'])
+      expect(maybe_code).to eq(nil)
+      expect(result['subject_alt_names']).to eq('foo.com')
+    end
+
+    it 'accepts DNS and IP alt names' do
+      result, maybe_code = subject.parse(['--subject-alt-names', 'DNS:foo.com,IP:123.456.789'])
+      expect(maybe_code).to eq(nil)
+      expect(result['subject_alt_names']).to eq('DNS:foo.com,IP:123.456.789')
+    end
+
+    it 'prepends "DNS" to unprefixed alt names' do
+      expect(subject.munge_alt_names('foo.com,IP:123.456.789')).to eq('DNS:foo.com, IP:123.456.789')
+    end
+
+    it 'adds subject alt names to the intermediate CA cert' do
+      digest = subject.default_signing_digest
+      valid_until = Time.now + 1000
+
+      root_key = subject.create_private_key(4096)
+      root_cert = subject.self_signed_ca(root_key, "root", valid_until, digest)
+      int_key = subject.create_private_key(4096)
+      int_csr = subject.create_csr(int_key, "int_ca", digest)
+      int_cert = subject.sign_intermediate(root_key, root_cert, int_csr, valid_until, digest, "DNS:bar.net, IP:123.123.0.1")
+      expect(int_cert.extensions[4].to_s).to eq("subjectAltName = DNS:bar.net, IP Address:123.123.0.1")
+    end
+
+    it 'chooses the default alt names when none are configured' do
+      facter = class_double(Facter).as_stubbed_const
+      expect(facter).to receive(:value).with(:fqdn) { 'foo.bar.net' }
+      expect(facter).to receive(:value).with(:domain) { 'bar.net' }
+      sans = subject.choose_alt_names('', '')
+      expect(sans).to eq('DNS:foo.bar.net, DNS:puppet, DNS:puppet.bar.net')
+    end
+
+    it 'prefers alt names from the CLI to those in settings' do
+      sans = subject.choose_alt_names('foo.com', 'bar.net')
+      expect(sans).to eq('DNS:foo.com')
+    end
+
+    it 'uses settings alt names when none are specified from the CLI' do
+      sans = subject.choose_alt_names('', 'bar.net')
+      expect(sans).to eq('DNS:bar.net')
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the ability to specify subject alternative names for
the intermediate signing cert when using the `generate` action. These
can be configured via a flag, or read from the puppet.conf file. If none
are provided, Puppet's default set of alt names will be added. This
supports both DNS and IP alt names. If type is not specified, DNS names
are assumed.