### PR TITLE
(SERVER-2275) Refactor code to make an HTTP client

### DIFF
--- a/lib/puppetserver/ca/revoke_action.rb
+++ b/lib/puppetserver/ca/revoke_action.rb
@@ -1,5 +1,5 @@
 require 'puppetserver/ca/utils'
-require 'puppetserver/utils/http_utilities'
+require 'puppetserver/utils/http_client'
 require 'puppetserver/utils/file_utilities'
 require 'puppetserver/ca/puppet_config'
 
@@ -93,13 +93,17 @@ BANNER
       end
 
       def revoke_certs(certnames, settings)
-        url = HttpUtilities.make_ca_url(settings[:ca_server],
-                       settings[:ca_port],
-                       'certificate_status')
+        client = HttpClient.new(settings[:localcacert],
+                                settings[:certificate_revocation],
+                                settings[:hostcrl])
+
+        url = client.make_ca_url(settings[:ca_server],
+                                 settings[:ca_port],
+                                 'certificate_status')
 
         # results will be a list of trues & falses based on the success
         # of revocations
-        results = HttpUtilities.with_connection(url, settings) do |connection|
+        results = client.with_connection(url) do |connection|
           certnames.map do |certname|
             url.resource_name = certname
             result = connection.put(REQUEST_BODY, url)

--- a/spec/puppetserver/ca/clean_action_spec.rb
+++ b/spec/puppetserver/ca/clean_action_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 require 'puppetserver/ca/clean_action'
 require 'puppetserver/ca/logger'
-require 'puppetserver/utils/http_utilities'
+require 'puppetserver/utils/http_client'
 
 RSpec.describe Puppetserver::Ca::CleanAction do
   let(:stdout) { StringIO.new }
@@ -56,8 +56,10 @@ RSpec.describe Puppetserver::Ca::CleanAction do
     let(:connection) { double }
 
     before do
-      allow(Puppetserver::Utils::HttpUtilities).
+      allow_any_instance_of(Puppetserver::Utils::HttpClient).
         to receive(:with_connection).and_yield(connection)
+      allow_any_instance_of(Puppetserver::Utils::HttpClient).
+        to receive(:make_store)
     end
 
     it 'logs success and returns zero if revoked and cleaned' do

--- a/spec/puppetserver/ca/revoke_action_spec.rb
+++ b/spec/puppetserver/ca/revoke_action_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 require 'puppetserver/ca/revoke_action'
 require 'puppetserver/ca/logger'
-require 'puppetserver/utils/http_utilities'
+require 'puppetserver/utils/http_client'
 
 RSpec.describe Puppetserver::Ca::RevokeAction do
   let(:stdout) { StringIO.new }
@@ -54,8 +54,10 @@ RSpec.describe Puppetserver::Ca::RevokeAction do
     let(:connection) { double }
 
     before do
-      allow(Puppetserver::Utils::HttpUtilities).
+      allow_any_instance_of(Puppetserver::Utils::HttpClient).
         to receive(:with_connection).and_yield(connection)
+      allow_any_instance_of(Puppetserver::Utils::HttpClient).
+        to receive(:make_store)
     end
 
     it 'logs success and returns zero if revoked' do

--- a/spec/puppetserver/utils/http_client_spec.rb
+++ b/spec/puppetserver/utils/http_client_spec.rb
@@ -1,14 +1,12 @@
 require 'spec_helper'
-require 'puppetserver/utils/http_utilities'
+require 'puppetserver/utils/http_client'
 require 'puppetserver/ca/logger'
 require 'puppetserver/ca/generate_action'
 require 'utils/ssl'
 require 'fileutils'
 
-RSpec.describe Puppetserver::Utils::HttpUtilities do
+RSpec.describe Puppetserver::Utils::HttpClient do
   include Utils::SSL
-
-  subject { Puppetserver::Utils::HttpUtilities }
 
   it 'creates a store that can validate connections to CA' do
     stdout = StringIO.new
@@ -53,7 +51,10 @@ RSpec.describe Puppetserver::Utils::HttpUtilities do
       FileUtils.cp(settings[:cacert], settings[:localcacert])
       FileUtils.cp(settings[:cacrl], settings[:hostcrl])
 
-      store = subject.make_store(settings[:localcacert], :chain, settings[:hostcrl])
+      client = Puppetserver::Utils::HttpClient.new(settings[:localcacert],
+                                                   :chain,
+                                                   settings[:hostcrl])
+      store = client.store
       hostcert = OpenSSL::X509::Certificate.new(File.read(settings[:hostcert]))
       cacert = OpenSSL::X509::Certificate.new(File.read(settings[:cacert]))
 


### PR DESCRIPTION
Refactor to create an actual HTTP client object that
initializes SSL state once and stores it, allowing
multiple connections to be made from it.