### PR TITLE
(maint) Prevent the `generate` command from overwriting the CA

### DIFF
--- a/lib/puppetserver/ca/generate_action.rb
+++ b/lib/puppetserver/ca/generate_action.rb
@@ -95,29 +95,20 @@ BANNER
           [settings[:cacrl], [int_crl, root_crl]]
         ]
 
-        errors = check_for_existing_files(file_properties)
-        return errors if errors.any?
+        errors = FileUtilities.check_for_existing_files(file_properties.map { |prop| prop.first })
+        if errors.any?
+          errors << "If you would really like to replace your CA, please delete the existing files first.
+Note that any certificates that were issued by this CA will become invalid if you
+replace it!"
+          Utils.handle_errors(@logger, errors)
+          return errors
+        end
 
         file_properties.each do |location, content|
           FileUtilities.write_file(location, content, 0640)
         end
 
         return []
-      end
-
-      def check_for_existing_files(files)
-        errors = []
-
-        files.each do |location, content|
-          errors << "A CA file already exists at #{location}." if File.exist?(location)
-        end
-
-        if errors.any?
-          errors << "If you would really like to regenerate your CA, please delete the existing files first.
-Note that any certificates that were issued by this CA will become invalid if you
-regenerate it!"
-        end
-        return errors
       end
 
       def self_signed_ca(key, name, valid_until, signing_digest)

--- a/lib/puppetserver/utils/file_utilities.rb
+++ b/lib/puppetserver/utils/file_utilities.rb
@@ -34,6 +34,17 @@ module Puppetserver
         errors
       end
 
+      def self.check_for_existing_files(one_or_more_paths)
+        errors = []
+        Array(one_or_more_paths).each do |path|
+          if File.exist?(path)
+            errors << "Existing file at '#{path}'"
+          end
+        end
+
+        errors
+      end
+
       def initialize
         @user, @group = find_user_and_group
       end

--- a/spec/puppetserver/ca/generate_action_spec.rb
+++ b/spec/puppetserver/ca/generate_action_spec.rb
@@ -12,10 +12,14 @@ RSpec.describe Puppetserver::Ca::GenerateAction do
 
   let(:stdout) { StringIO.new }
   let(:stderr) { StringIO.new }
+  let(:logger) { Puppetserver::Ca::Logger.new(:info, stdout, stderr) }
+
+  subject { Puppetserver::Ca::GenerateAction.new(logger) }
+
   let(:usage) { /.*Usage:.* puppetserver ca generate.*Display this generate specific help output.*/m }
 
   it 'prints the help output & returns 1 if invalid flags are given' do
-    exit_code = Puppetserver::Ca::Cli.run(['generate', '--hello'], stdout, stderr)
+    _, exit_code = subject.parse({ '--hello' => ''})
     expect(stderr.string).to match(/Error.*--hello/m)
     expect(stderr.string).to match(usage)
     expect(exit_code).to eq(1)
@@ -24,7 +28,7 @@ RSpec.describe Puppetserver::Ca::GenerateAction do
   it 'does not print the help output if called correctly' do
     Dir.mktmpdir do |tmpdir|
       with_temp_dirs tmpdir do |conf|
-        exit_code = Puppetserver::Ca::Cli.run(['generate', '--config', conf], stdout, stderr)
+        exit_code = subject.run({ 'config' => conf })
         expect(stderr.string).to be_empty
         expect(stdout.string.strip).to eq("Generation succeeded. Find your files in #{tmpdir}/ca")
         expect(exit_code).to eq(0)
@@ -35,12 +39,26 @@ RSpec.describe Puppetserver::Ca::GenerateAction do
   it 'generates a bundle ca_crt file, ca_key, int_key, and ca_crl file' do
     Dir.mktmpdir do |tmpdir|
       with_temp_dirs tmpdir do |conf|
-        exit_code = Puppetserver::Ca::Cli.run(['generate', '--config', conf], stdout, stderr)
+        exit_code = subject.run({ 'config' => conf })
         expect(exit_code).to eq(0)
         expect(File.exist?(File.join(tmpdir, 'ca', 'ca_crt.pem'))).to be true
         expect(File.exist?(File.join(tmpdir, 'ca', 'ca_key.pem'))).to be true
         expect(File.exist?(File.join(tmpdir, 'ca', 'root_key.pem'))).to be true
         expect(File.exist?(File.join(tmpdir, 'ca', 'ca_crl.pem'))).to be true
+      end
+    end
+  end
+
+  it 'will not overwrite existing CA files' do
+    Dir.mktmpdir do |tmpdir|
+      with_temp_dirs tmpdir do |conf|
+        exit_code = subject.run({ 'config' => conf })
+        expect(exit_code).to eq(0)
+
+        exit_code2 = subject.run({ 'config' => conf })
+        expect(exit_code2).to eq(1)
+        expect(stderr.string).to match(/A CA file already exists.*/)
+        expect(stderr.string).to match(/.*please delete the existing files.*/)
       end
     end
   end

--- a/spec/puppetserver/ca/generate_action_spec.rb
+++ b/spec/puppetserver/ca/generate_action_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Puppetserver::Ca::GenerateAction do
 
         exit_code2 = subject.run({ 'config' => conf })
         expect(exit_code2).to eq(1)
-        expect(stderr.string).to match(/A CA file already exists.*/)
+        expect(stderr.string).to match(/Existing file.*/)
         expect(stderr.string).to match(/.*please delete the existing files.*/)
       end
     end


### PR DESCRIPTION
Previously, the `generate` command would overwrite any existing CA files
in the target locations. This meant that if a user called
`generate` more than once, they could accidentally nuke thier CA,
thereby making all certs issued by it invalid. This commit makes the
command exit if any of the CA files already exist, and prompts the user to
remove them manually if they really want to regenerate their CA.