### PR TITLE
(maint) Allow 200 response to process correctly

### DIFF
--- a/lib/puppetserver/ca/sign_action.rb
+++ b/lib/puppetserver/ca/sign_action.rb
@@ -106,7 +106,7 @@ Options:
       def get_all_certs(settings)
         result = get_certificate_statuses(settings)
 
-        unless result.code == 200
+        unless result.code == '200'
             @logger.err 'Error:'
             @logger.err "    #{result.inspect}"
             return nil


### PR DESCRIPTION
When --all flag is included we ask for all csrs from
the CA.  Code is returned in string format so we must
read it as such.