### PR TITLE
(SERVER-2286) Create a master cert as part of `generate` action

### DIFF
--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -4,6 +4,7 @@ require 'puppetserver/ca/utils/file_system'
 require 'puppetserver/ca/host'
 require 'puppetserver/ca/utils/cli_parsing'
 require 'puppetserver/ca/utils/signing_digest'
+require 'facter'
 
 module Puppetserver
   module Ca
@@ -15,7 +16,20 @@ module Puppetserver
           ["basicConstraints", "CA:TRUE", true],
           ["keyUsage", "keyCertSign, cRLSign", true],
           ["subjectKeyIdentifier", "hash", false],
+          ["nsComment", "Puppet Server Internal Certificate", false],
           ["authorityKeyIdentifier", "keyid:always", false]
+        ].freeze
+
+        SSL_SERVER_CERT = "1.3.6.1.5.5.7.3.1"
+        SSL_CLIENT_CERT = "1.3.6.1.5.5.7.3.2"
+
+        MASTER_EXTENSIONS = [
+          ["basicConstraints", "CA:FALSE", true],
+          ["nsComment", "Puppet Server Internal Certificate", false],
+          ["authorityKeyIdentifier", "keyid:always", false],
+          ["extendedKeyUsage", "#{SSL_SERVER_CERT}, #{SSL_CLIENT_CERT}", true],
+          ["keyUsage", "keyEncipherment, digitalSignature", true],
+          ["subjectKeyIdentifier", "hash", false]
         ].freeze
 
         # Make the certificate valid as of yesterday, because so many people's
@@ -30,10 +44,17 @@ module Puppetserver
 Usage:
   puppetserver ca generate [--help]
   puppetserver ca generate [--config PATH]
+  puppetserver ca generate [--subject-alt-names ALTNAME1[,ALTNAME2...]]
 
 Description:
 Generate a root and intermediate signing CA for Puppet Server
 and store generated CA keys, certs, and crls on disk.
+
+The `--subject-alt-names` flag can be used to add SANs to the
+certificate generated for the Puppet master. Multiple names can be
+listed as a comma separated string. These can be either DNS names or
+IP addresses, differentiated by prefixes: `DNS:foo.bar.com,IP:123.456.789`.
+Names with no prefix will be treated as DNS names.
 
 To determine the target location, the default puppet.conf
 is consulted for custom values. If using a custom puppet.conf
@@ -62,19 +83,24 @@ BANNER
           signer = SigningDigest.new
           return 1 if CliParsing.handle_errors(@logger, signer.errors)
 
+          if input['subject_alt_names'].empty?
+            subject_alt_names = munge_alt_names(puppet.settings[:subject_alt_names])
+          else
+            subject_alt_names = munge_alt_names(input['subject_alt_names'])
+          end
+
           # Generate root and intermediate ca and put all the certificates, crls,
           # and keys where they should go.
-          generate_root_and_intermediate_ca(puppet.settings, signer.digest)
+          generate_pki(puppet.settings, signer.digest, subject_alt_names)
 
           # Puppet's internal CA expects these file to exist.
-          FileSystem.ensure_file(puppet.settings[:serial], "001", 0640)
-          FileSystem.ensure_file(puppet.settings[:cert_inventory], "", 0640)
+          FileSystem.ensure_file(puppet.settings[:serial], "002", 0640)
 
           @logger.inform "Generation succeeded. Find your files in #{puppet.settings[:cadir]}"
           return 0
         end
 
-        def generate_root_and_intermediate_ca(settings, signing_digest)
+        def generate_pki(settings, signing_digest, subject_alt_names = '')
           valid_until = Time.now + settings[:ca_ttl]
           host = Puppetserver::Ca::Host.new(signing_digest)
 
@@ -87,16 +113,42 @@ BANNER
           int_cert = sign_intermediate(root_key, root_cert, int_csr, valid_until, signing_digest)
           int_crl = create_crl_for(int_cert, int_key, valid_until, signing_digest)
 
-          FileSystem.ensure_dir(settings[:cadir])
+          master_key = host.create_private_key(settings[:keylength])
+          master_csr = host.create_csr(settings[:certname], master_key)
+          master_cert = sign_master_cert(int_key, int_cert, master_csr,
+                                       valid_until, signing_digest, subject_alt_names)
 
-          file_properties = [
+          FileSystem.ensure_dir(settings[:cadir])
+          FileSystem.ensure_dir(settings[:certdir])
+          FileSystem.ensure_dir(settings[:privatekeydir])
+          FileSystem.ensure_dir(settings[:publickeydir])
+
+          FileSystem.write_file(settings[:cert_inventory],
+                                inventory_entry(master_cert),
+                                0644)
+
+          public_files = [
             [settings[:cacert], [int_cert, root_cert]],
-            [settings[:cakey], int_key],
-            [settings[:rootkey], root_key],
-            [settings[:cacrl], [int_crl, root_crl]]
+            [settings[:cacrl], [int_crl, root_crl]],
+            [settings[:hostcert], master_cert],
+            [settings[:localcacert], [int_cert, root_cert]],
+            [settings[:localcacrl], [int_crl, root_crl]],
+            [settings[:hostpubkey], [master_key.public_key]],
+            [settings[:capub], [int_key.public_key]],
           ]
 
-          file_properties.each do |location, content|
+          private_files = [
+            [settings[:hostprivkey], master_key],
+            [settings[:rootkey], root_key],
+            [settings[:cakey], int_key],
+          ]
+
+          public_files.each do |location, content|
+            @logger.warn "#{location} exists, overwriting" if File.exist?(location)
+            FileSystem.write_file(location, content, 0644)
+          end
+
+          private_files.each do |location, content|
             @logger.warn "#{location} exists, overwriting" if File.exist?(location)
             FileSystem.write_file(location, content, 0640)
           end
@@ -123,6 +175,15 @@ BANNER
           cert.sign(key, signing_digest)
 
           cert
+        end
+
+        def inventory_entry(cert)
+          "0x%04x %s %s %s" % [cert.serial, format_time(cert.not_before),
+                               format_time(cert.not_after), cert.subject]
+        end
+
+        def format_time(time)
+          time.strftime('%Y-%m-%dT%H:%M:%S%Z')
         end
 
         def extension_factory_for(ca, cert = nil)
@@ -168,25 +229,60 @@ BANNER
             extension = ef.create_extension(*ext)
             cert.add_extension(extension)
           end
+
           cert.sign(ca_key, signing_digest)
 
           cert
         end
 
-        def parse(args)
+        def sign_master_cert(int_key, int_cert, csr, valid_until, signing_digest, subject_alt_names)
+          cert = OpenSSL::X509::Certificate.new
+          cert.public_key = csr.public_key
+          cert.subject = csr.subject
+          cert.issuer = int_cert.subject
+          cert.version = 2
+          cert.serial = 1
+          cert.not_before = CERT_VALID_FROM
+          cert.not_after = valid_until
+
+          ef = extension_factory_for(int_cert, cert)
+          MASTER_EXTENSIONS.each do |ext|
+            extension = ef.create_extension(*ext)
+            cert.add_extension(extension)
+          end
+
+          if !subject_alt_names.empty?
+            alt_names_ext = ef.create_extension("subjectAltName", subject_alt_names, false)
+            cert.add_extension(alt_names_ext)
+          end
+
+          cert.sign(int_key, signing_digest)
+          cert
+        end
+
+        def munge_alt_names(names)
+          raw_names = names.split(/\s*,\s*/).map(&:strip)
+          munged_names = raw_names.map do |name|
+            # Prepend the DNS tag if no tag was specified
+            if !name.start_with?("IP:") && !name.start_with?("DNS:")
+              "DNS:#{name}"
+            else
+              name
+            end
+          end.sort.uniq.join(", ")
+        end
+
+        def parse(cli_args)
           results = {}
           parser = self.class.parser(results)
-
-          errors = CliParsing.parse_with_errors(parser, args)
-
+          errors = CliParsing.parse_with_errors(parser, cli_args)
           errors_were_handled = CliParsing.handle_errors(@logger, errors, parser.help)
-
           exit_code = errors_were_handled ? 1 : nil
-
           return results, exit_code
         end
 
         def self.parser(parsed = {})
+          parsed['subject_alt_names'] = ''
           OptionParser.new do |opts|
             opts.banner = BANNER
             opts.on('--help', 'Display this generate specific help output') do |help|
@@ -194,6 +290,10 @@ BANNER
             end
             opts.on('--config CONF', 'Path to puppet.conf') do |conf|
               parsed['config'] = conf
+            end
+            opts.on('--subject-alt-names NAME1[,NAME2]',
+                    'Subject alternative names for the CA signing cert') do |sans|
+              parsed['subject_alt_names'] = sans
             end
           end
         end

--- a/lib/puppetserver/ca/action/sign.rb
+++ b/lib/puppetserver/ca/action/sign.rb
@@ -173,8 +173,8 @@ Options:
 
           errors = CliParsing.parse_with_errors(parser, args)
 
-          if check_flag_usage(results)
-            errors << check_flag_usage(results)
+          if err = check_flag_usage(results)
+            errors << err
           end
 
           errors_were_handled = CliParsing.handle_errors(@logger, errors, parser.help)

--- a/lib/puppetserver/ca/config/puppet.rb
+++ b/lib/puppetserver/ca/config/puppet.rb
@@ -107,7 +107,8 @@ module Puppetserver
             [:certname, default_certname],
             [:server, '$certname'],
             [:masterport, '8140'],
-            [:privatekeydir, '$ssldir/private_keys']
+            [:privatekeydir, '$ssldir/private_keys'],
+            [:publickeydir, '$ssldir/public_keys'],
           ]
 
           dependent_defaults = {
@@ -116,6 +117,7 @@ module Puppetserver
             :keylength => 4096,
             :cacert => '$cadir/ca_crt.pem',
             :cakey => '$cadir/ca_key.pem',
+            :capub => '$cadir/ca_pub.pem',
             :rootkey => '$cadir/root_key.pem',
             :cacrl => '$cadir/ca_crl.pem',
             :serial => '$cadir/serial',
@@ -123,9 +125,11 @@ module Puppetserver
             :ca_server => '$server',
             :ca_port => '$masterport',
             :localcacert => '$certdir/ca.pem',
+            :localcacrl => '$ssldir/crl.pem',
             :hostcert => '$certdir/$certname.pem',
             :hostcrl => '$ssldir/crl.pem',
             :hostprivkey => '$privatekeydir/$certname.pem',
+            :hostpubkey => '$publickeydir/$certname.pem',
             :publickeydir => '$ssldir/public_keys',
             :ca_ttl => '15y',
             :certificate_revocation => 'true',
@@ -150,6 +154,9 @@ module Puppetserver
           # Some special cases where we need to manipulate config settings:
           settings[:ca_ttl] = munge_ttl_setting(settings[:ca_ttl])
           settings[:certificate_revocation] = parse_crl_usage(settings[:certificate_revocation])
+
+          # rename dns_alt_names to subject_alt_names now that we support IP alt names
+          settings[:subject_alt_names] = overrides.fetch(:dns_alt_names, "puppet,$certname")
 
           settings.each do |key, value|
             next unless value.is_a? String

--- a/spec/puppetserver/ca/action/generate_spec.rb
+++ b/spec/puppetserver/ca/action/generate_spec.rb
@@ -4,15 +4,21 @@ require 'utils/ssl'
 require 'tmpdir'
 require 'fileutils'
 
-require 'puppetserver/ca/action/import'
 require 'puppetserver/ca/cli'
+require 'puppetserver/ca/action/generate'
+require 'puppetserver/ca/logger'
+require 'puppetserver/ca/utils/signing_digest'
+require 'puppetserver/ca/host'
 
 RSpec.describe Puppetserver::Ca::Action::Generate do
   include Utils::SSL
 
   let(:stdout) { StringIO.new }
   let(:stderr) { StringIO.new }
+  let(:logger) { Puppetserver::Ca::Logger.new(:info, stdout, stderr) }
   let(:usage) { /.*Usage:.* puppetserver ca generate.*Display this generate specific help output.*/m }
+
+  subject { Puppetserver::Ca::Action::Generate.new(logger) }
 
   it 'prints the help output & returns 1 if invalid flags are given' do
     exit_code = Puppetserver::Ca::Cli.run(['generate', '--hello'], stdout, stderr)
@@ -35,13 +41,46 @@ RSpec.describe Puppetserver::Ca::Action::Generate do
   it 'generates a bundle ca_crt file, ca_key, int_key, and ca_crl file' do
     Dir.mktmpdir do |tmpdir|
       with_temp_dirs tmpdir do |conf|
-        exit_code = Puppetserver::Ca::Cli.run(['generate', '--config', conf], stdout, stderr)
+        exit_code = subject.run({ 'config' => conf, 'subject_alt_names' => '' })
         expect(exit_code).to eq(0)
         expect(File.exist?(File.join(tmpdir, 'ca', 'ca_crt.pem'))).to be true
         expect(File.exist?(File.join(tmpdir, 'ca', 'ca_key.pem'))).to be true
         expect(File.exist?(File.join(tmpdir, 'ca', 'root_key.pem'))).to be true
         expect(File.exist?(File.join(tmpdir, 'ca', 'ca_crl.pem'))).to be true
       end
+    end
+  end
+
+  describe 'subject alternative names' do
+    it 'accepts unprefixed alt names' do
+      result, maybe_code = subject.parse(['--subject-alt-names', 'foo.com'])
+      expect(maybe_code).to eq(nil)
+      expect(result['subject_alt_names']).to eq('foo.com')
+    end
+
+    it 'accepts DNS and IP alt names' do
+      result, maybe_code = subject.parse(['--subject-alt-names', 'DNS:foo.com,IP:123.456.789'])
+      expect(maybe_code).to eq(nil)
+      expect(result['subject_alt_names']).to eq('DNS:foo.com,IP:123.456.789')
+    end
+
+    it 'prepends "DNS" to unprefixed alt names' do
+      expect(subject.munge_alt_names('foo.com,IP:123.456.789')).to eq('DNS:foo.com, IP:123.456.789')
+    end
+
+    it 'adds subject alt names to the master cert' do
+      digest = Puppetserver::Ca::Utils::SigningDigest.new.digest
+      host = Puppetserver::Ca::Host.new(digest)
+      valid_until = Time.now + 1000
+      root_key = host.create_private_key(4096)
+      root_cert = subject.self_signed_ca(root_key, "root", valid_until, digest)
+      int_key = host.create_private_key(4096)
+      int_csr = host.create_csr("int_ca", int_key)
+      int_cert = subject.sign_intermediate(root_key, root_cert, int_csr, valid_until, digest)
+      master_key = host.create_private_key(4096)
+      master_csr = host.create_csr("master", master_key)
+      master_cert = subject.sign_master_cert(int_key, int_cert, master_csr, valid_until, digest, "DNS:bar.net, IP:123.123.0.1")
+      expect(master_cert.extensions[6].to_s).to eq("subjectAltName = DNS:bar.net, IP Address:123.123.0.1")
     end
   end
 end

--- a/spec/puppetserver/ca/utils/http_client_spec.rb
+++ b/spec/puppetserver/ca/utils/http_client_spec.rb
@@ -21,12 +21,16 @@ RSpec.describe Puppetserver::Ca::Utils::HttpClient do
       cadir = tmpdir
       cacert = File.join(tmpdir, 'ca_crt.pem')
       cakey = File.join(tmpdir, 'ca_key.pem')
+      capub = File.join(tmpdir, 'ca_pub.pem')
       rootkey = File.join(tmpdir, 'root_key.pem')
       cacrl = File.join(tmpdir, 'ca_crl.pem')
       localcacert = File.join(tmpdir, 'localcacert.pem')
+      localcacrl = File.join(tmpdir, 'localcacrl.pem')
       hostcrl = File.join(tmpdir, 'hostcrl.pem')
       hostcert = File.join(tmpdir, 'hostcert.pem')
       hostprivkey = File.join(tmpdir, 'hostkey.pem')
+      hostpubkey = File.join(tmpdir, 'hostpubkey.pem')
+      inventory = File.join(tmpdir, 'inventory.txt')
 
       settings = {
         ca_ttl: (5 * 365 * 24 * 60 * 60),
@@ -36,16 +40,24 @@ RSpec.describe Puppetserver::Ca::Utils::HttpClient do
         cadir: cadir,
         cacert: cacert,
         cakey: cakey,
+        capub: capub,
         rootkey: rootkey,
         cacrl: cacrl,
         localcacert: localcacert,
+        localcacrl: localcacrl,
         hostcrl: hostcrl,
         hostcert: hostcert,
         hostprivkey: hostprivkey,
+        certname: 'foo',
+        certdir: cadir,
+        privatekeydir: cadir,
+        publickeydir: cadir,
+        hostpubkey: hostpubkey,
+        cert_inventory: inventory,
       }
 
       signer = Puppetserver::Ca::Utils::SigningDigest.new
-      generate_action.generate_root_and_intermediate_ca(settings, signer.digest)
+      generate_action.generate_pki(settings, signer.digest)
 
       hostkey = OpenSSL::PKey::RSA.new(2048)
       cakey_content = OpenSSL::PKey.read(File.read(settings[:cakey]))


### PR DESCRIPTION
This commit updates the `generate` action to also create a master
certificate signed by the intermediate CA. This cert support subect
alternative names that can be customized via Puppet's dns_alt_names
setting or the `--subject-alt-names` flag.