### PR TITLE
(maint) Prevent `generate` and `import` from overwriting existing CA files

### DIFF
--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -131,7 +131,7 @@ BANNER
             [settings[:hostpubkey], master_key.public_key],
             [settings[:capub], int_key.public_key],
             [settings[:cert_inventory], inventory_entry(master_cert)],
-            [settings[:serial], "002"],
+            [settings[:serial], "0x0002"],
           ]
 
           private_files = [
@@ -140,13 +140,16 @@ BANNER
             [settings[:cakey], int_key],
           ]
 
-          errors = FileSystem.check_for_existing_files(public_files.map { |f| f.first })
-          errors += FileSystem.check_for_existing_files(private_files.map { |f| f.first })
+          errors = FileSystem.check_for_existing_files(public_files.map(&:first))
+          errors += FileSystem.check_for_existing_files(private_files.map(&:first))
 
-          if errors.any?
-            errors << "If you would really like to replace your CA, please delete the existing files first.
-  Note that any certificates that were issued by this CA will become invalid if you
-  replace it!"
+          if !errors.empty?
+            instructions = <<-ERR
+If you would really like to replace your CA, please delete the existing files first.
+Note that any certificates that were issued by this CA will become invalid if you
+replace it!
+ERR
+            errors << instructions
             return errors
           end
 

--- a/lib/puppetserver/ca/action/import.rb
+++ b/lib/puppetserver/ca/action/import.rb
@@ -41,13 +41,27 @@ BANNER
           files = [bundle_path, key_path, chain_path, config_path].compact
 
           errors = FileSystem.validate_file_paths(files)
-          return 1 if log_possible_errors(errors)
+          return 1 if CliParsing.handle_errors(@logger, errors)
 
           loader = X509Loader.new(bundle_path, key_path, chain_path)
-          return 1 if log_possible_errors(loader.errors)
+          return 1 if CliParsing.handle_errors(@logger, loader.errors)
 
           puppet = Config::Puppet.parse(config_path)
-          return 1 if log_possible_errors(puppet.errors)
+          return 1 if CliParsing.handle_errors(@logger, puppet.errors)
+
+          target_locations = [puppet.settings[:cacert],
+                              puppet.settings[:cakey],
+                              puppet.settings[:cacrl],
+                              puppet.settings[:serial],
+                              puppet.settings[:cert_inventory]]
+          errors = FileSystem.check_for_existing_files(target_locations)
+          if errors.any?
+            errors << "If you would really like to replace your CA, please delete the existing files first.
+  Note that any certificates that were issued by this CA will become invalid if you
+  replace it!"
+            CliParsing.handle_errors(@logger, errors)
+            return 1
+          end
 
           FileSystem.ensure_dir(puppet.settings[:cadir])
 
@@ -65,40 +79,29 @@ BANNER
           return 0
         end
 
-        def log_possible_errors(maybe_errors)
-          errors = Array(maybe_errors).compact
-          unless errors.empty?
-            @logger.err "Error:"
-            errors.each do |message|
-              @logger.err "    #{message}"
-            end
-            return true
+        def check_flag_usage(results)
+          if results['cert-bundle'].nil? || results['private-key'].nil? || results['crl-chain'].nil?
+            '    Missing required argument' + "\n" +
+            '    --cert-bundle, --private-key, --crl-chain are required'
           end
         end
 
-      def check_flag_usage(results)
-        if results['cert-bundle'].nil? || results['private-key'].nil? || results['crl-chain'].nil?
-          '    Missing required argument' + "\n" +
-          '    --cert-bundle, --private-key, --crl-chain are required'
+        def parse(args)
+          results = {}
+          parser = self.class.parser(results)
+
+          errors = CliParsing.parse_with_errors(parser, args)
+
+          if check_flag_usage(results)
+            errors << check_flag_usage(results)
+          end
+
+          errors_were_handled = CliParsing.handle_errors(@logger, errors, parser.help)
+
+          exit_code = errors_were_handled ? 1 : nil
+
+          return results, exit_code
         end
-      end
-
-      def parse(args)
-        results = {}
-        parser = self.class.parser(results)
-
-        errors = CliParsing.parse_with_errors(parser, args)
-
-        if check_flag_usage(results)
-          errors << check_flag_usage(results)
-        end
-
-        errors_were_handled = CliParsing.handle_errors(@logger, errors, parser.help)
-
-        exit_code = errors_were_handled ? 1 : nil
-
-        return results, exit_code
-      end
 
         def self.parser(parsed = {})
           OptionParser.new do |opts|

--- a/lib/puppetserver/ca/utils/file_system.rb
+++ b/lib/puppetserver/ca/utils/file_system.rb
@@ -35,6 +35,16 @@ module Puppetserver
           errors
         end
 
+        def self.check_for_existing_files(one_or_more_paths)
+          errors = []
+          Array(one_or_more_paths).each do |path|
+            if File.exist?(path)
+              errors << "Existing file at '#{path}'"
+            end
+          end
+          errors
+        end
+
         def initialize
           @user, @group = find_user_and_group
         end

--- a/spec/puppetserver/ca/action/generate_spec.rb
+++ b/spec/puppetserver/ca/action/generate_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Puppetserver::Ca::Action::Generate do
   subject { Puppetserver::Ca::Action::Generate.new(logger) }
 
   it 'prints the help output & returns 1 if invalid flags are given' do
-    _, exit_code = subject.parse({ '--hello' => ''})
+    _, exit_code = subject.parse(['--hello'])
     expect(stderr.string).to match(/Error.*--hello/m)
     expect(stderr.string).to match(usage)
     expect(exit_code).to eq(1)

--- a/spec/puppetserver/ca/action/generate_spec.rb
+++ b/spec/puppetserver/ca/action/generate_spec.rb
@@ -3,8 +3,6 @@ require 'utils/ssl'
 
 require 'tmpdir'
 require 'fileutils'
-
-require 'puppetserver/ca/cli'
 require 'puppetserver/ca/action/generate'
 require 'puppetserver/ca/logger'
 require 'puppetserver/ca/utils/signing_digest'
@@ -21,7 +19,7 @@ RSpec.describe Puppetserver::Ca::Action::Generate do
   subject { Puppetserver::Ca::Action::Generate.new(logger) }
 
   it 'prints the help output & returns 1 if invalid flags are given' do
-    exit_code = Puppetserver::Ca::Cli.run(['generate', '--hello'], stdout, stderr)
+    _, exit_code = subject.parse({ '--hello' => ''})
     expect(stderr.string).to match(/Error.*--hello/m)
     expect(stderr.string).to match(usage)
     expect(exit_code).to eq(1)
@@ -30,7 +28,7 @@ RSpec.describe Puppetserver::Ca::Action::Generate do
   it 'does not print the help output if called correctly' do
     Dir.mktmpdir do |tmpdir|
       with_temp_dirs tmpdir do |conf|
-        exit_code = Puppetserver::Ca::Cli.run(['generate', '--config', conf], stdout, stderr)
+        exit_code = subject.run({ 'config' => conf, 'subject_alt_names' => '' })
         expect(stderr.string).to be_empty
         expect(stdout.string.strip).to eq("Generation succeeded. Find your files in #{tmpdir}/ca")
         expect(exit_code).to eq(0)
@@ -81,6 +79,19 @@ RSpec.describe Puppetserver::Ca::Action::Generate do
       master_csr = host.create_csr("master", master_key)
       master_cert = subject.sign_master_cert(int_key, int_cert, master_csr, valid_until, digest, "DNS:bar.net, IP:123.123.0.1")
       expect(master_cert.extensions[6].to_s).to eq("subjectAltName = DNS:bar.net, IP Address:123.123.0.1")
+    end
+  end
+
+  it 'will not overwrite existing CA files' do
+    Dir.mktmpdir do |tmpdir|
+      with_temp_dirs tmpdir do |conf|
+        exit_code = subject.run({ 'config' => conf, 'subject_alt_names' => '' })
+        expect(exit_code).to eq(0)
+        exit_code2 = subject.run({ 'config' => conf, 'subject_alt_names' => ''})
+        expect(exit_code2).to eq(1)
+        expect(stderr.string).to match(/Existing file.*/)
+        expect(stderr.string).to match(/.*please delete the existing files.*/)
+      end
     end
   end
 end

--- a/spec/puppetserver/ca/action/import_spec.rb
+++ b/spec/puppetserver/ca/action/import_spec.rb
@@ -4,20 +4,23 @@ require 'utils/ssl'
 require 'tmpdir'
 require 'fileutils'
 
+require 'puppetserver/ca/logger'
 require 'puppetserver/ca/action/import'
-require 'puppetserver/ca/cli'
 
 RSpec.describe Puppetserver::Ca::Action::Import do
   include Utils::SSL
 
   let(:stdout) { StringIO.new }
   let(:stderr) { StringIO.new }
+  let(:logger) { Puppetserver::Ca::Logger.new(:info, stdout, stderr) }
   let(:usage) do
     /.*Usage:.* puppetserver ca import.*Display this import specific help output.*/m
   end
 
+  subject { Puppetserver::Ca::Action::Import.new(logger) }
+
   it 'prints the help output & returns 1 if invalid flags are given' do
-    exit_code = Puppetserver::Ca::Cli.run(['import', '--hello'], stdout, stderr)
+    _, exit_code = subject.parse(['--hello'])
     expect(stderr.string).to match(/Error.*--hello/m)
     expect(stderr.string).to match(usage)
     expect(exit_code).to be 1
@@ -25,7 +28,7 @@ RSpec.describe Puppetserver::Ca::Action::Import do
 
 
   it 'prints the help output & returns 1 if no input is given' do
-    exit_code = Puppetserver::Ca::Cli.run(['import'], stdout, stderr)
+    _, exit_code = subject.parse([])
     expect(stderr.string).to match(usage)
     expect(exit_code).to be 1
   end
@@ -33,71 +36,44 @@ RSpec.describe Puppetserver::Ca::Action::Import do
   it 'does not print the help output if called correctly' do
     Dir.mktmpdir do |tmpdir|
       with_files_in tmpdir do |bundle, key, chain, conf|
-        exit_code = Puppetserver::Ca::Cli.run(['import',
-                                                '--cert-bundle', bundle,
-                                                '--private-key', key,
-                                                '--crl-chain', chain,
-                                                '--config', conf],
-                                              stdout, stderr)
+        _, maybe_code = subject.parse(['--cert-bundle', bundle,
+                                       '--private-key', key,
+                                       '--crl-chain', chain,
+                                       '--config', conf])
         expect(stderr.string).to be_empty
-        expect(exit_code).to be 0
-      end
-    end
-  end
-
-  it 'accepts a --config flag' do
-    Dir.mktmpdir do |tmpdir|
-      with_files_in tmpdir do |bundle, key, chain, conf|
-        Puppetserver::Ca::Cli.run(['import',
-                                    '--config', conf,
-                                    '--cert-bundle', bundle,
-                                    '--private-key', key,
-                                    '--crl-chain', chain],
-                                    stdout,
-                                    stderr)
+        expect(maybe_code).to be nil
       end
     end
   end
 
   describe 'validation' do
-    it 'requires the --cert-bundle, --private-key, and --crl-chain options' do
-      out1, err1 = StringIO.new, StringIO.new
-      exit_code = Puppetserver::Ca::Cli.run(
-                    ['import', '--private-key', 'foo', '--crl-chain', 'bar'],
-                    out1,
-                    err1)
-      expect(err1.string).to include('Missing required argument')
-      expect(err1.string).to match(usage)
+    it 'requires the --cert-bundle' do
+      _, exit_code = subject.parse(['--private-key', 'foo', '--crl-chain', 'bar'])
+      expect(stderr.string).to include('Missing required argument')
+      expect(stderr.string).to match(usage)
       expect(exit_code).to be 1
+    end
 
-      out2, err2 = StringIO.new, StringIO.new
-      exit_code = Puppetserver::Ca::Cli.run(
-                    ['import', '--cert-bundle', 'foo', '--crl-chain', 'bar'],
-                    out2,
-                    err2)
-      expect(err2.string).to include('Missing required argument')
-      expect(err2.string).to match(usage)
+    it 'requires the --private-key' do
+      _, exit_code = subject.parse(['--cert-bundle', 'foo', '--crl-chain', 'bar'])
+      expect(stderr.string).to include('Missing required argument')
+      expect(stderr.string).to match(usage)
       expect(exit_code).to be 1
+    end
 
-      out3, err3 = StringIO.new, StringIO.new
-      exit_code = Puppetserver::Ca::Cli.run(
-                    ['import', '--private-key', 'foo', '--cert-bundle', 'bar'],
-                    out3,
-                    err3)
-      expect(err3.string).to include('Missing required argument')
-      expect(err3.string).to match(usage)
+    it 'requires the --crl-chain' do
+      _, exit_code = subject.parse(['--cert-bundle', 'foo', '--private-key', 'bar'])
+      expect(stderr.string).to include('Missing required argument')
+      expect(stderr.string).to match(usage)
       expect(exit_code).to be 1
     end
 
     it 'requires cert-bundle, private-key, and crl-chain to be readable' do
       # All errors are surfaced from validations
       Dir.mktmpdir do |tmpdir|
-        exit_code = Puppetserver::Ca::Cli.run(
-                      ['import',
-                       '--cert-bundle', File.join(tmpdir, 'cert_bundle.pem'),
-                       '--private-key', File.join(tmpdir, 'private_key.pem'),
-                       '--crl-chain', File.join(tmpdir, 'crl_chain.pem')],
-                      stdout, stderr)
+        exit_code = subject.run({ 'cert-bundle' => File.join(tmpdir, 'cert_bundle.pem'),
+                                  'private-key' => File.join(tmpdir, 'private_key.pem'),
+                                  'crl-chain' => File.join(tmpdir, 'crl_chain.pem') })
         expect(stderr.string).to match(/Could not read .*cert_bundle.pem/)
         expect(stderr.string).to match(/Could not read .*private_key.pem/)
         expect(stderr.string).to match(/Could not read .*crl_chain.pem/)
@@ -113,14 +89,9 @@ RSpec.describe Puppetserver::Ca::Action::Import do
             f.puts 'garbage'
             f.puts '-----END CERTIFICATE-----'
           end
-          exit_code = Puppetserver::Ca::Cli.run(
-                        ['import',
-                         '--cert-bundle', bundle,
-                         '--private-key', key,
-                         '--crl-chain', chain],
-                        stdout,
-                        stderr)
-
+          exit_code = subject.run({ 'cert-bundle' => bundle,
+                                    'private-key'=> key,
+                                    'crl-chain' => chain })
           expect(stderr.string).to match(/Could not parse .*bundle.pem/)
           expect(stderr.string).to include('garbage')
         end
@@ -131,14 +102,9 @@ RSpec.describe Puppetserver::Ca::Action::Import do
       Dir.mktmpdir do |tmpdir|
         with_files_in tmpdir do |bundle, key, chain, conf|
           File.open(bundle, 'w') {|f| f.puts '' }
-          exit_code = Puppetserver::Ca::Cli.run(
-                        ['import',
-                         '--cert-bundle', bundle,
-                         '--private-key', key,
-                         '--crl-chain', chain],
-                        stdout,
-                        stderr)
-
+          exit_code = subject.run({ 'cert-bundle' => bundle,
+                                    'private-key'=> key,
+                                    'crl-chain' => chain })
           expect(stderr.string).to match(/Could not detect .*bundle.pem/)
         end
       end
@@ -148,14 +114,9 @@ RSpec.describe Puppetserver::Ca::Action::Import do
       Dir.mktmpdir do |tmpdir|
         with_files_in tmpdir do |bundle, key, chain, conf|
           File.open(key, 'w') {|f| f.puts '' }
-          exit_code = Puppetserver::Ca::Cli.run(
-                        ['import',
-                         '--cert-bundle', bundle,
-                         '--private-key', key,
-                         '--crl-chain', chain],
-                        stdout,
-                        stderr)
-
+          exit_code = subject.run({ 'cert-bundle' => bundle,
+                                    'private-key'=> key,
+                                    'crl-chain' => chain })
           expect(stderr.string).to match(/Could not parse .*key.pem/)
         end
       end
@@ -165,14 +126,9 @@ RSpec.describe Puppetserver::Ca::Action::Import do
       Dir.mktmpdir do |tmpdir|
         with_files_in tmpdir do |bundle, key, chain, conf|
           File.open(key, 'w') {|f| f.puts OpenSSL::PKey::RSA.new(1024).to_pem }
-          exit_code = Puppetserver::Ca::Cli.run(
-                        ['import',
-                         '--cert-bundle', bundle,
-                         '--private-key', key,
-                         '--crl-chain', chain],
-                        stdout,
-                        stderr)
-
+          exit_code = subject.run({ 'cert-bundle' => bundle,
+                                    'private-key'=> key,
+                                    'crl-chain' => chain })
           expect(stderr.string).to include('Private key and certificate do not match')
         end
       end
@@ -186,14 +142,9 @@ RSpec.describe Puppetserver::Ca::Action::Import do
             f.puts 'garbage'
             f.puts '-----END X509 CRL-----'
           end
-          exit_code = Puppetserver::Ca::Cli.run(
-                        ['import',
-                         '--cert-bundle', bundle,
-                         '--private-key', key,
-                         '--crl-chain', chain],
-                        stdout,
-                        stderr)
-
+          exit_code = subject.run({ 'cert-bundle' => bundle,
+                                    'private-key'=> key,
+                                    'crl-chain' => chain })
           expect(stderr.string).to match(/Could not parse .*chain.pem/)
           expect(stderr.string).to include('garbage')
         end
@@ -204,14 +155,9 @@ RSpec.describe Puppetserver::Ca::Action::Import do
       Dir.mktmpdir do |tmpdir|
         with_files_in tmpdir do |bundle, key, chain, conf|
           File.open(chain, 'w') {|f| f.puts '' }
-          exit_code = Puppetserver::Ca::Cli.run(
-                        ['import',
-                         '--cert-bundle', bundle,
-                         '--private-key', key,
-                         '--crl-chain', chain],
-                        stdout,
-                        stderr)
-
+          exit_code = subject.run({ 'cert-bundle' => bundle,
+                                    'private-key'=> key,
+                                    'crl-chain' => chain })
           expect(stderr.string).to match(/Could not detect .*chain.pem/)
         end
       end
@@ -231,14 +177,9 @@ RSpec.describe Puppetserver::Ca::Action::Import do
             f.puts crls[1..-1]
           end
 
-          exit_code = Puppetserver::Ca::Cli.run(
-                        ['import',
-                         '--cert-bundle', bundle,
-                         '--private-key', key,
-                         '--crl-chain', chain],
-                        stdout,
-                        stderr)
-
+          exit_code = subject.run({ 'cert-bundle' => bundle,
+                                    'private-key'=> key,
+                                    'crl-chain' => chain })
           expect(stderr.string).to include('Leaf CRL was not issued by leaf certificate')
         end
       end
@@ -274,13 +215,9 @@ RSpec.describe Puppetserver::Ca::Action::Import do
           f.puts root_crl.to_pem
         end
 
-        exit_code = Puppetserver::Ca::Cli.run(['import',
-                                                '--private-key', key_file,
-                                                '--cert-bundle', bundle_file,
-                                                '--crl-chain', chain_file],
-                                                stdout,
-                                                stderr)
-
+        exit_code = subject.run({ 'cert-bundle' => bundle_file,
+                                    'private-key'=> key_file,
+                                    'crl-chain' => chain_file })
         expect(stderr.string).to include('Leaf certificate could not be validated')
       end
     end
@@ -289,13 +226,10 @@ RSpec.describe Puppetserver::Ca::Action::Import do
       Dir.mktmpdir do |tmpdir|
         with_files_in tmpdir do |bundle, key, chain, conf|
           FileUtils.rm conf
-          exit_code = Puppetserver::Ca::Cli.run(['import',
-                                                  '--config', conf,
-                                                  '--cert-bundle', bundle,
-                                                  '--private-key', key,
-                                                  '--crl-chain', chain],
-                                                  stdout,
-                                                  stderr)
+          exit_code = subject.run({ 'config' => conf,
+                                    'cert-bundle' => bundle,
+                                    'private-key'=> key,
+                                    'crl-chain' => chain })
           expect(stderr.string).to match(/Could not read file .*puppet.conf/)
         end
       end
@@ -311,18 +245,40 @@ RSpec.describe Puppetserver::Ca::Action::Import do
               cadir = #{tmpdir}/ca
           INI
         end
-        exit_code = Puppetserver::Ca::Cli.run(['import',
-                                                '--cert-bundle', bundle,
-                                                '--private-key', key,
-                                                '--crl-chain', chain,
-                                                '--config', conf],
-                                                stdout,
-                                                stderr)
-
+        exit_code = subject.run({ 'config' => conf,
+                                  'cert-bundle' => bundle,
+                                  'private-key'=> key,
+                                  'crl-chain' => chain })
         expect(exit_code).to eq(0)
         expect(File.exist?(File.join(tmpdir, 'ca', 'ca_crl.pem'))).to be true
         expect(File.exist?(File.join(tmpdir, 'ca', 'ca_key.pem'))).to be true
         expect(File.exist?(File.join(tmpdir, 'ca', 'ca_crt.pem'))).to be true
+      end
+    end
+  end
+
+  it 'does not overwrite existing CA files' do
+    Dir.mktmpdir do |tmpdir|
+      with_files_in tmpdir do |bundle, key, chain, conf|
+        File.open conf, 'w' do |f|
+          f.puts(<<-INI)
+            [master]
+              cadir = #{tmpdir}/ca
+          INI
+        end
+        exit_code = subject.run({ 'config' => conf,
+                                  'cert-bundle' => bundle,
+                                  'private-key'=> key,
+                                  'crl-chain' => chain })
+        expect(exit_code).to eq(0)
+
+        exit_code2 = subject.run({ 'config' => conf,
+                                  'cert-bundle' => bundle,
+                                  'private-key'=> key,
+                                  'crl-chain' => chain })
+        expect(exit_code2).to eq(1)
+        expect(stderr.string).to match(/Existing file.*/)
+        expect(stderr.string).to match(/.*please delete the existing files.*/)
       end
     end
   end

--- a/spec/puppetserver/ca/action/import_spec.rb
+++ b/spec/puppetserver/ca/action/import_spec.rb
@@ -216,8 +216,8 @@ RSpec.describe Puppetserver::Ca::Action::Import do
         end
 
         exit_code = subject.run({ 'cert-bundle' => bundle_file,
-                                    'private-key'=> key_file,
-                                    'crl-chain' => chain_file })
+                                  'private-key'=> key_file,
+                                  'crl-chain' => chain_file })
         expect(stderr.string).to include('Leaf certificate could not be validated')
       end
     end

--- a/spec/puppetserver/ca/utils/http_client_spec.rb
+++ b/spec/puppetserver/ca/utils/http_client_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Puppetserver::Ca::Utils::HttpClient do
       hostprivkey = File.join(tmpdir, 'hostkey.pem')
       hostpubkey = File.join(tmpdir, 'hostpubkey.pem')
       inventory = File.join(tmpdir, 'inventory.txt')
+      serial = File.join(tmpdir, 'serial')
 
       settings = {
         ca_ttl: (5 * 365 * 24 * 60 * 60),
@@ -54,6 +55,7 @@ RSpec.describe Puppetserver::Ca::Utils::HttpClient do
         publickeydir: cadir,
         hostpubkey: hostpubkey,
         cert_inventory: inventory,
+        serial: '002',
       }
 
       signer = Puppetserver::Ca::Utils::SigningDigest.new

--- a/spec/puppetserver/ca/utils/http_client_spec.rb
+++ b/spec/puppetserver/ca/utils/http_client_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Puppetserver::Ca::Utils::HttpClient do
         publickeydir: cadir,
         hostpubkey: hostpubkey,
         cert_inventory: inventory,
-        serial: '002',
+        serial: serial,
       }
 
       signer = Puppetserver::Ca::Utils::SigningDigest.new


### PR DESCRIPTION
Supersedes https://github.com/puppetlabs/puppetserver-ca-cli/pull/18