### PR TITLE
(SERVER-2287) Add custom auth extension to master cert

### DIFF
--- a/lib/puppetserver/ca/action/list.rb
+++ b/lib/puppetserver/ca/action/list.rb
@@ -111,7 +111,7 @@ Options:
 
         def get_all_certs(settings)
           result = Puppetserver::Ca::CertificateAuthority.new(@logger, settings).get_certificate_statuses
-          JSON.parse(result.body)
+          JSON.parse(result.body) if result
         end
 
         def parse(args)

--- a/lib/puppetserver/ca/local_certificate_authority.rb
+++ b/lib/puppetserver/ca/local_certificate_authority.rb
@@ -16,6 +16,8 @@ module Puppetserver
       SSL_SERVER_CERT = "1.3.6.1.5.5.7.3.1"
       SSL_CLIENT_CERT = "1.3.6.1.5.5.7.3.2"
 
+      CLI_AUTH_EXT_OID = "1.3.6.1.4.1.34380.1.3.39"
+
       MASTER_EXTENSIONS = [
         ["basicConstraints", "CA:FALSE", true],
         ["nsComment", "Puppet Server Internal Certificate", false],
@@ -96,6 +98,10 @@ module Puppetserver
           extension = ef.create_extension(*ext)
           cert.add_extension(extension)
         end
+
+        # Status API access for the CA CLI
+        cli_auth_ext = OpenSSL::X509::Extension.new(CLI_AUTH_EXT_OID, OpenSSL::ASN1::UTF8String.new("true").to_der, false)
+        cert.add_extension(cli_auth_ext)
       end
 
       def add_subject_alt_names_extension(cert, ef)

--- a/spec/puppetserver/ca/action/generate_spec.rb
+++ b/spec/puppetserver/ca/action/generate_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Puppetserver::Ca::Action::Generate do
           master_cert_file = File.join(tmpdir, 'ssl', 'certs', 'foo.pem')
           expect(File.exist?(master_cert_file)).to be true
           master_cert = OpenSSL::X509::Certificate.new(File.read(master_cert_file))
-          expect(master_cert.extensions[6].to_s).to eq("subjectAltName = DNS:puppet, DNS:foo")
+          expect(master_cert.extensions[7].to_s).to eq("subjectAltName = DNS:puppet, DNS:foo")
         end
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe Puppetserver::Ca::Action::Generate do
           master_cert_file = File.join(tmpdir, 'ssl', 'certs', 'foo.pem')
           expect(File.exist?(master_cert_file)).to be true
           master_cert = OpenSSL::X509::Certificate.new(File.read(master_cert_file))
-          expect(master_cert.extensions[6].to_s).to eq("subjectAltName = DNS:foo, DNS:bar.net, IP Address:123.123.0.1")
+          expect(master_cert.extensions[7].to_s).to eq("subjectAltName = DNS:foo, DNS:bar.net, IP Address:123.123.0.1")
         end
       end
     end

--- a/spec/puppetserver/ca/action/import_spec.rb
+++ b/spec/puppetserver/ca/action/import_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe Puppetserver::Ca::Action::Import do
           master_cert_file = File.join(tmpdir, 'ssl', 'certs', 'foo.pem')
           expect(File.exist?(master_cert_file)).to be true
           master_cert = OpenSSL::X509::Certificate.new(File.read(master_cert_file))
-          expect(master_cert.extensions[6].to_s).to eq("subjectAltName = DNS:puppet, DNS:foo")
+          expect(master_cert.extensions[7].to_s).to eq("subjectAltName = DNS:puppet, DNS:foo")
         end
       end
     end
@@ -343,7 +343,7 @@ RSpec.describe Puppetserver::Ca::Action::Import do
           master_cert_file = File.join(tmpdir, 'ssl', 'certs', 'foo.pem')
           expect(File.exist?(master_cert_file)).to be true
           master_cert = OpenSSL::X509::Certificate.new(File.read(master_cert_file))
-          expect(master_cert.extensions[6].to_s).to eq("subjectAltName = DNS:foo, DNS:bar.net, IP Address:123.123.0.1")
+          expect(master_cert.extensions[7].to_s).to eq("subjectAltName = DNS:foo, DNS:bar.net, IP Address:123.123.0.1")
         end
       end
     end

--- a/spec/puppetserver/ca/local_certificate_authority_spec.rb
+++ b/spec/puppetserver/ca/local_certificate_authority_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
         int_key, int_cert, int_crl = subject.create_intermediate_cert(root_key, root_cert)
 
         _, cert = subject.create_master_cert(int_key, int_cert)
-        expect(cert.extensions.count).to eq(7)
+        expect(cert.extensions.count).to eq(8)
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
         int_key, int_cert, int_crl = subject.create_intermediate_cert(root_key, root_cert)
 
         _, cert = subject.create_master_cert(int_key, int_cert)
-        expect(cert.extensions.count).to eq(9)
+        expect(cert.extensions.count).to eq(10)
       end
     end
   end


### PR DESCRIPTION
This commit adds a new custom extension to the master cert when
generating it. This extension is checked by tk-auth when allowing access
to the certificate_status and certificate_statuses endpoints. This is to
help ensure that only requests from the puppet master's cert can access
those endpoints.