### PR TITLE
(maint) Correctly encode SAN extReqs in CSRs

### DIFF
--- a/lib/puppetserver/ca/action/create.rb
+++ b/lib/puppetserver/ca/action/create.rb
@@ -153,7 +153,10 @@ BANNER
           private_key = host.create_private_key(settings[:keylength])
           extensions = []
           if !settings[:subject_alt_names].empty?
-            extensions << OpenSSL::X509::Extension.new("subjectAltName", settings[:subject_alt_names], false)
+            ef = OpenSSL::X509::ExtensionFactory.new
+            extensions << ef.create_extension("subjectAltName",
+                                              settings[:subject_alt_names],
+                                              false)
           end
           csr = host.create_csr(name: certname,
                                 key: private_key,


### PR DESCRIPTION
Previously we passed a bare string into Extension.new, which would not
do the special pre-processing that an ExtensionFactory will do for us to
ensure that subjectAltNames were properly encoded. Because what was
encoded was a string, the printing and manual inspection lead us to
believe that everything was encoded properly, however the
ExtensionFactory will create a sequence with elements typed by their
kind of name (eg DNS or IP). More rigorous CA code was not allowing the
encoded string in the place of what should have been an encoded
sequence.

This moves us to use the ExtensionFactory so we do not need to care
about the convoluted nature of CSR encoding. It also adds a test to
prove that what is encoded in our CSRs are sequences that can be decoded
into their correct individual elements.