### PR TITLE
(maint) Return 24 when revoking or cleaning unsigned CSRs

### DIFF
--- a/lib/puppetserver/ca/action/clean.rb
+++ b/lib/puppetserver/ca/action/clean.rb
@@ -87,9 +87,15 @@ BANNER
           puppet = Config::Puppet.parse(config)
           return 1 if CliParsing.handle_errors(@logger, puppet.errors)
 
-          passed = clean_certs(certnames, puppet.settings)
-
-          return passed ? 0 : 1
+          result = clean_certs(certnames, puppet.settings)
+          case result
+          when :success
+            return 0
+          when :invalid
+            return 24
+          when :not_found, :error
+            return 1
+          end
         end
 
         def clean_certs(certnames, settings)

--- a/lib/puppetserver/ca/action/revoke.rb
+++ b/lib/puppetserver/ca/action/revoke.rb
@@ -86,9 +86,16 @@ BANNER
           puppet = Config::Puppet.parse(config)
           return 1 if CliParsing.handle_errors(@logger, puppet.errors)
 
-          passed = revoke_certs(certnames, puppet.settings)
+          result =  revoke_certs(certnames, puppet.settings)
 
-          return passed ? 0 : 1
+          case result
+          when :success
+            return 0
+          when :invalid
+            return 24
+          when :not_found, :error
+            return 1
+          end
         end
 
         def revoke_certs(certnames, settings)

--- a/lib/puppetserver/ca/certificate_authority.rb
+++ b/lib/puppetserver/ca/certificate_authority.rb
@@ -18,31 +18,49 @@ module Puppetserver
         @ca_port = settings[:ca_port]
       end
 
+      def worst_result(previous_result, current_result)
+        %i{success invalid not_found error}.each do |state|
+          if previous_result == state
+            return current_result
+          elsif current_result == state
+            return previous_result
+          else
+            next
+          end
+        end
+      end
+
       # Returns a URI-like wrapper around CA specific urls
       def make_ca_url(resource_type = nil, certname = nil)
         HttpClient::URL.new('https', @ca_server, @ca_port, 'puppet-ca', 'v1', resource_type, certname)
       end
 
       def sign_certs(certnames)
-        put(certnames,
-            resource_type: 'certificate_status',
-            body: SIGN_BODY,
-            type: :sign)
+        results = put(certnames,
+                      resource_type: 'certificate_status',
+                      body: SIGN_BODY,
+                      type: :sign)
+
+        results.all? {|result| result == :success }
       end
 
       def revoke_certs(certnames)
-        put(certnames,
-            resource_type: 'certificate_status',
-            body: REVOKE_BODY,
-            type: :revoke)
+        results = put(certnames,
+                    resource_type: 'certificate_status',
+                    body: REVOKE_BODY,
+                    type: :revoke)
+
+        results.reduce {|prev, curr| worst_result(prev, curr) }
       end
 
       def submit_certificate_request(certname, csr)
-        put([certname],
-            resource_type: 'certificate_request',
-            body: csr.to_pem,
-            headers: {'Content-Type' => 'text/plain'},
-            type: :submit)
+        results = put([certname],
+                    resource_type: 'certificate_request',
+                    body: csr.to_pem,
+                    headers: {'Content-Type' => 'text/plain'},
+                    type: :submit)
+
+        results.all? {|result| result == :success }
       end
 
       # Make an HTTP PUT request to CA
@@ -60,8 +78,6 @@ module Puppetserver
             process_results(type, certname, result)
           end
         end
-
-        results.all?
       end
 
       # logs the action and returns true/false for success
@@ -71,45 +87,49 @@ module Puppetserver
           case result.code
           when '204'
             @logger.inform "Successfully signed certificate request for #{certname}"
-            return true
+            return :success
           when '404'
             @logger.err 'Error:'
             @logger.err "    Could not find certificate request for #{certname}"
-            return false
+            return :not_found
           else
             @logger.err 'Error:'
             @logger.err "    When attempting to sign certificate request '#{certname}', received"
             @logger.err "      code: #{result.code}"
             @logger.err "      body: #{result.body.to_s}" if result.body
-            return false
+            return :error
           end
         when :revoke
           case result.code
           when '200', '204'
             @logger.inform "Revoked certificate for #{certname}"
-            return true
+            return :success
           when '404'
             @logger.err 'Error:'
             @logger.err "    Could not find certificate for #{certname}"
-            return false
+            return :not_found
+          when '409'
+            @logger.err 'Error:'
+            @logger.err "    Could not revoke unsigned csr for #{certname}"
+            return :invalid
           else
             @logger.err 'Error:'
             @logger.err "    When attempting to revoke certificate '#{certname}', received:"
             @logger.err "      code: #{result.code}"
             @logger.err "      body: #{result.body.to_s}" if result.body
-            return false
+            return :error
           end
         when :submit
           case result.code
           when '200', '204'
             @logger.inform "Successfully submitted certificate request for #{certname}"
-            return true
+            return :success
           else
             @logger.err 'Error:'
             @logger.err "    When attempting to submit certificate request for '#{certname}', received:"
             @logger.err "      code: #{result.code}"
             @logger.err "      body: #{result.body.to_s}" if result.body
-            return false
+            return :error
           end
         end
       end


### PR DESCRIPTION
I don't know, seems like a weird behavior to keep.