### PR TITLE
(SERVER-2320) Allow generation of an authorized cert offline

### DIFF
--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -1,9 +1,12 @@
 require 'puppetserver/ca/utils/cli_parsing'
 require 'puppetserver/ca/host'
 require 'puppetserver/ca/certificate_authority'
+require 'puppetserver/ca/local_certificate_authority'
+require 'puppetserver/ca/x509_loader'
 require 'puppetserver/ca/config/puppet'
 require 'puppetserver/ca/utils/file_system'
 require 'puppetserver/ca/utils/signing_digest'
+require 'puppetserver/ca/utils/config'
 
 module Puppetserver
   module Ca
@@ -20,12 +23,26 @@ module Puppetserver
         BANNER = <<-BANNER
 Usage:
   puppetserver ca generate [--help]
-  puppetserver ca generate [--config PATH] [--certname NAME[,NAME]]
+  puppetserver ca generate --certname NAME[,NAME] [--config PATH]
                            [--subject-alt-names NAME[,NAME]]
+                           [--ca-client]
 
 Description:
 Generates a new certificate signed by the intermediate CA
 and stores generated keys and certs on disk.
+
+If the `--ca-client` flag is passed, the cert will be generated
+offline, without using Puppet Server's signing code, and will add
+a special extension authorizing it to talk to the CA API. This can
+be used for regenerating the master's host cert, or for manually
+setting up other nodes to be CA clients. Do not distribute certs
+generated this way to any node that you do not intend to have
+administrative access to the CA (e.g. the ability to sign a cert).
+
+Since the `--ca-client` causes a cert to be generated offline, it
+should ONLY be used when Puppet Server is NOT running, to avoid
+conflicting with the actions of the CA service. This will be
+mandatory in a future release.
 
 To determine the target location, the default puppet.conf
 is consulted for custom values. If using a custom puppet.conf
@@ -55,6 +72,11 @@ BANNER
             opts.on('--subject-alt-names NAME[,NAME]',
                     'Subject alternative names for the generated cert') do |sans|
               parsed['subject-alt-names'] = sans
+            end
+            opts.on('--ca-client',
+                    'Whether this cert will be used to request CA actions.\
+                    Causes the cert to be generated offline.') do |ca_client|
+              parsed['ca-client'] = true
             end
           end
         end
@@ -103,27 +125,66 @@ BANNER
 
           # Load, resolve, and validate puppet config settings
           settings_overrides = {}
-          # Since puppet expects the key to be called 'dns_alt_names', we need to use that here
-          # to ensure that the overriding works correctly.
-          settings_overrides[:dns_alt_names] = input['subject-alt-names'] unless input['subject-alt-names'].empty?
           puppet = Config::Puppet.new(config_path)
           puppet.load(settings_overrides)
           return 1 if CliParsing.handle_errors(@logger, puppet.errors)
+
+          # We don't want generate to respect the alt names setting, since it is usually
+          # used to generate certs for other nodes
+          alt_names = input['subject-alt-names']
 
           # Load most secure signing digest we can for csr signing.
           signer = SigningDigest.new
           return 1 if CliParsing.handle_errors(@logger, signer.errors)
 
           # Generate and save certs and associated keys
-          all_passed = generate_certs(certnames, puppet.settings, signer.digest)
+          if input['ca-client']
+            all_passed = generate_authorized_certs(certnames, alt_names, puppet.settings, signer.digest)
+          else
+            all_passed = generate_certs(certnames, alt_names, puppet.settings, signer.digest)
+          end
           return all_passed ? 0 : 1
+        end
+
+        # Certs authorized to talk to the CA API need to be signed offline,
+        # in order to securely add the special auth extension.
+        def generate_authorized_certs(certnames, alt_names, settings, digest)
+          # Make sure we have all the directories where we will be writing files
+          FileSystem.ensure_dirs([settings[:ssldir],
+                                  settings[:certdir],
+                                  settings[:privatekeydir],
+                                  settings[:publickeydir]])
+
+          ca = Puppetserver::Ca::LocalCertificateAuthority.new(digest, settings)
+          ca_cert, ca_key = ca.load_ca
+          return false if CliParsing.handle_errors(@logger, ca.errors)
+
+          passed = certnames.map do |certname|
+            errors = check_for_existing_ssl_files(certname, settings)
+            next false if CliParsing.handle_errors(@logger, errors)
+
+            current_alt_names = process_alt_names(alt_names, certname)
+
+            # For certs signed offline, any alt names are added directly to the cert,
+            # rather than to the CSR.
+            key, csr = generate_key_csr(certname, settings, digest)
+            next false unless csr
+
+            cert = ca.sign_authorized_cert(ca_key, ca_cert, csr, current_alt_names)
+            next false unless save_file(cert.to_pem, certname, settings[:certdir], "Certificate")
+            next false unless save_file(cert.to_pem, certname, settings[:signeddir], "Certificate")
+            next false unless save_keys(certname, settings, key)
+            ca.update_serial_file(cert.serial + 1)
+            true
+          end
+          passed.all?
         end
 
         # Generate csrs and keys, then submit them to CA, request for the CA to sign
         # them, download the signed certificates from the CA, and finally save
         # the signed certs and associated keys. Returns true if all certs were
         # successfully created and saved.
-        def generate_certs(certnames, settings, digest)
+        def generate_certs(certnames, alt_names, settings, digest)
           # Make sure we have all the directories where we will be writing files
           FileSystem.ensure_dirs([settings[:ssldir],
                                   settings[:certdir],
@@ -133,13 +194,18 @@ BANNER
           ca = Puppetserver::Ca::CertificateAuthority.new(@logger, settings)
 
           passed = certnames.map do |certname|
-            key, csr = generate_key_csr(certname, settings, digest)
-            return false unless csr
-            return false unless ca.submit_certificate_request(certname, csr)
-            return false unless ca.sign_certs([certname])
+            errors = check_for_existing_ssl_files(certname, settings)
+            next false if CliParsing.handle_errors(@logger, errors)
+
+            current_alt_names = process_alt_names(alt_names, certname)
+
+            key, csr = generate_key_csr(certname, settings, digest, current_alt_names)
+            next false unless csr
+            next false unless ca.submit_certificate_request(certname, csr)
+            next false unless ca.sign_certs([certname])
             if result = ca.get_certificate(certname)
-              save_file(result.body, certname, settings[:certdir], "Certificate")
-              save_keys(certname, settings, key)
+              next false unless save_file(result.body, certname, settings[:certdir], "Certificate")
+              next false unless save_keys(certname, settings, key)
               true
             else
               false
@@ -148,14 +214,16 @@ BANNER
           passed.all?
         end
 
-        def generate_key_csr(certname, settings, digest)
+        # For certs signed offline, any alt names are added directly to the cert,
+        # rather than to the CSR.
+        def generate_key_csr(certname, settings, digest, alt_names = '')
           host = Puppetserver::Ca::Host.new(digest)
           private_key = host.create_private_key(settings[:keylength])
           extensions = []
-          if !settings[:subject_alt_names].empty?
+          if !alt_names.empty?
             ef = OpenSSL::X509::ExtensionFactory.new
             extensions << ef.create_extension("subjectAltName",
-                                              settings[:subject_alt_names],
+                                              alt_names,
                                               false)
           end
           csr = host.create_csr(name: certname,
@@ -169,15 +237,44 @@ BANNER
 
         def save_keys(certname, settings, key)
           public_key = key.public_key
-          save_file(key, certname, settings[:privatekeydir], "Private key")
-          save_file(public_key, certname, settings[:publickeydir], "Public key")
+          return false unless save_file(key, certname, settings[:privatekeydir], "Private key")
+          return false unless save_file(public_key, certname, settings[:publickeydir], "Public key")
+          true
         end
 
         def save_file(content, certname, dir, type)
           location = File.join(dir, "#{certname}.pem")
-          @logger.warn "#{type} #{certname}.pem already exists, overwriting" if File.exist?(location)
-          FileSystem.write_file(location, content, 0640)
-          @logger.inform "Successfully saved #{type.downcase} for #{certname} to #{location}"
+          if File.exist?(location)
+            @logger.err "#{type} #{certname}.pem already exists. Please delete it if you really want to regenerate it."
+            false
+          else
+            FileSystem.write_file(location, content, 0640)
+            @logger.inform "Successfully saved #{type.downcase} for #{certname} to #{location}"
+            true
+          end
+        end
+
+        def check_for_existing_ssl_files(certname, settings)
+          files = [ File.join(settings[:certdir], "#{certname}.pem"),
+                    File.join(settings[:privatekeydir], "#{certname}.pem"),
+                    File.join(settings[:publickeydir], "#{certname}.pem"),
+                    File.join(settings[:signeddir], "#{certname}.pem"), ]
+          errors = Puppetserver::Ca::Utils::FileSystem.check_for_existing_files(files)
+          if !errors.empty?
+            errors << "Please delete these files if you really want to generate a new cert for #{certname}."
+          end
+          errors
+        end
+
+        def process_alt_names(alt_names, certname)
+          return '' if alt_names.empty?
+
+          current_alt_names = alt_names.dup
+          # When validating the cert, OpenSSL will ignore the CN field if
+          # altnames are present, so we need to ensure that the certname is
+          # also listed among the alt names.
+          current_alt_names += ",DNS:#{certname}"
+          current_alt_names = Puppetserver::Ca::Utils::Config.munge_alt_names(current_alt_names)
         end
       end
     end

--- a/lib/puppetserver/ca/config/puppetserver.rb
+++ b/lib/puppetserver/ca/config/puppetserver.rb
@@ -8,8 +8,6 @@ module Puppetserver
       # Puppetserver or any TK config service. Uses the ruby-hocon gem for parsing.
       class PuppetServer
 
-        include Puppetserver::Ca::Utils::Config
-
         def self.parse(config_path = nil)
           instance = new(config_path)
           instance.load
@@ -50,7 +48,7 @@ module Puppetserver
         # Note that Puppet Server runs as the [pe-]puppet user but to
         # start/stop it you must be root.
         def user_specific_ca_dir
-          if running_as_root?
+          if Puppetserver::Ca::Utils::Config.running_as_root?
             '/etc/puppetlabs/puppetserver/ca'
           else
             "#{ENV['HOME']}/.puppetlabs/etc/puppetserver/ca"

--- a/lib/puppetserver/ca/utils/config.rb
+++ b/lib/puppetserver/ca/utils/config.rb
@@ -3,8 +3,20 @@ module Puppetserver
     module Utils
       module Config
 
-        def running_as_root?
+        def self.running_as_root?
           !Gem.win_platform? && Process::UID.eid == 0
+        end
+
+        def self.munge_alt_names(names)
+          raw_names = names.split(/\s*,\s*/).map(&:strip)
+          munged_names = raw_names.map do |name|
+            # Prepend the DNS tag if no tag was specified
+            if !name.start_with?("IP:") && !name.start_with?("DNS:")
+              "DNS:#{name}"
+            else
+              name
+            end
+          end.sort.uniq.join(", ")
         end
 
       end

--- a/spec/puppetserver/ca/action/setup_spec.rb
+++ b/spec/puppetserver/ca/action/setup_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Puppetserver::Ca::Action::Setup do
                                   'subject-alt-names' => '',
                                   'ca-name' => '',
                                   'certname' => '' })
+        puts stderr.string
         expect(stderr.string).to be_empty
         expect(stdout.string.strip).to eq("Generation succeeded. Find your files in #{tmpdir}/ca")
         expect(exit_code).to eq(0)


### PR DESCRIPTION
The cert used by the CA CLI needs to have a special auth extension that
is disallowed by the Puppet Server CA, to prevent any node from
requesting a cert with the special permissions. Previously, this cert
was always created along with the rest of the CA files.

This commit adds a way to generate an authorized cert with the special
extension, from an existing CA. The special cert is signed offline, not
through the main Puppet CA. It can be generated with values for the
master, or with values for other nodes. In the latter case the cert and
keys will need to be distributed manually.

This also updates `generate` to not use the `subject_alt_names`
setting. This setting is supposed to be specific to the master node, but
`generate` can be used to create certs for any node, and those shouldn't
necessarily have the master's alt names. When using `generate`, the user
needs to specify both certname and any alt names manually.