### PR TITLE
(maint) Create ca_pub file when importing a CA

### DIFF
--- a/lib/puppetserver/ca/action/import.rb
+++ b/lib/puppetserver/ca/action/import.rb
@@ -92,6 +92,7 @@ BANNER
             [settings[:hostpubkey], master_key.public_key],
             [settings[:hostcert], master_cert],
             [settings[:cert_inventory], ca.inventory_entry(master_cert)],
+            [settings[:capub], loader.key.public_key],
             [settings[:cadir] + '/infra_inventory.txt', ''],
             [settings[:cadir] + '/infra_serials', ''],
             [settings[:serial], "002"],

--- a/spec/shared_examples/setup.rb
+++ b/spec/shared_examples/setup.rb
@@ -34,6 +34,7 @@ RSpec.shared_examples 'properly sets up ca and ssl dir' do |action_class|
         files = [['ca', 'ca_crt.pem', '644'],
                  ['ca', 'ca_crl.pem', '644'],
                  ['ca', 'ca_key.pem', '640'],
+                 ['ca', 'ca_pub.pem', '644'],
                  ['ca', 'infra_crl.pem', '644'],
                  ['ca', 'inventory.txt', '644'],
                  ['ca', 'infra_inventory.txt', '644'],


### PR DESCRIPTION
Previously we were not extracting the CA's public key into a publicly
visible file when using the import command. This commit remedies that
and adds a test for it.