### PR TITLE
(SERVER-2345) Support autosigning when generating certs

### DIFF
--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -202,13 +202,22 @@ BANNER
             key, csr = generate_key_csr(certname, settings, digest, current_alt_names)
             next false unless csr
             next false unless ca.submit_certificate_request(certname, csr)
-            next false unless ca.sign_certs([certname])
+
+            # Check if the CA autosigned the cert
             if result = ca.get_certificate(certname)
+              @logger.inform "Certificate for #{certname} was autosigned."
               next false unless save_file(result.body, certname, settings[:certdir], "Certificate")
               next false unless save_keys(certname, settings, key)
               true
             else
-              false
+              next false unless ca.sign_certs([certname])
+              if result = ca.get_certificate(certname)
+                next false unless save_file(result.body, certname, settings[:certdir], "Certificate")
+                next false unless save_keys(certname, settings, key)
+                true
+              else
+                false
+              end
             end
           end
           passed.all?


### PR DESCRIPTION
Previously if the user tried to generate a cert that was autosigned by
the CA, the command would error, because it would request that the cert
be signed after it was already signed by autosign. This commit updates
the generate logic to take into account autosigning.