### PR TITLE
(SERVER-2351) Check CA service before generating certs offline

### DIFF
--- a/lib/puppetserver/ca/certificate_authority.rb
+++ b/lib/puppetserver/ca/certificate_authority.rb
@@ -41,7 +41,7 @@ module Puppetserver
                       body: SIGN_BODY,
                       type: :sign)
 
-        results.all? {|result| result == :success }
+        results.all? { |result| result == :success }
       end
 
       def revoke_certs(certnames)
@@ -50,7 +50,7 @@ module Puppetserver
                     body: REVOKE_BODY,
                     type: :revoke)
 
-        results.reduce {|prev, curr| worst_result(prev, curr) }
+        results.reduce { |prev, curr| worst_result(prev, curr) }
       end
 
       def submit_certificate_request(certname, csr)
@@ -60,7 +60,7 @@ module Puppetserver
                     headers: {'Content-Type' => 'text/plain'},
                     type: :submit)
 
-        results.all? {|result| result == :success }
+        results.all? { |result| result == :success }
       end
 
       # Make an HTTP PUT request to CA

--- a/lib/puppetserver/ca/utils/http_client.rb
+++ b/lib/puppetserver/ca/utils/http_client.rb
@@ -15,12 +15,20 @@ module Puppetserver
 
         attr_reader :store
 
-        def initialize(settings)
+        # Not all connections require a client cert to be present.
+        # For example, when querying the status endpoint.
+        def initialize(settings, with_client_cert: true)
           @store = make_store(settings[:localcacert],
                               settings[:certificate_revocation],
                               settings[:hostcrl])
-          @cert = load_cert(settings[:hostcert])
-          @key = load_key(settings[:hostprivkey])
+
+          if with_client_cert
+            @cert = load_cert(settings[:hostcert])
+            @key = load_key(settings[:hostprivkey])
+          else
+            @cert = nil
+            @key = nil
+          end
         end
 
         def load_cert(cert_path)


### PR DESCRIPTION
In order to avoid race conditions with serial numbers, we want to
avoid allowing multiple processes to issue certificates at the same
time. This commit adds a check to make sure that Puppet Server's CA
service is offline before issuing certs out-of-band using Ruby code,
when using `generate --ca-client`. It queries the simple status endpoint
and errors if it receives a "running" response from the server.