### PR TITLE
(SERVER-2335) Refactor LocalCertificateAuthority

### DIFF
--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -196,7 +196,7 @@ BANNER
             key, csr = generate_key_csr(certname, settings, digest)
             next false unless csr
 
-            cert = ca.sign_authorized_cert(ca.key, ca.cert, csr, current_alt_names)
+            cert = ca.sign_authorized_cert(csr, current_alt_names)
             next false unless save_file(cert.to_pem, certname, settings[:certdir], "Certificate")
             next false unless save_file(cert.to_pem, certname, settings[:signeddir], "Certificate")
             next false unless save_keys(certname, settings, key)

--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -183,7 +183,6 @@ BANNER
                                   settings[:publickeydir]])
 
           ca = Puppetserver::Ca::LocalCertificateAuthority.new(digest, settings)
-          ca_cert, ca_key = ca.load_ca
           return false if CliParsing.handle_errors(@logger, ca.errors)
 
           passed = certnames.map do |certname|
@@ -197,7 +196,7 @@ BANNER
             key, csr = generate_key_csr(certname, settings, digest)
             next false unless csr
 
-            cert = ca.sign_authorized_cert(ca_key, ca_cert, csr, current_alt_names)
+            cert = ca.sign_authorized_cert(ca.key, ca.cert, csr, current_alt_names)
             next false unless save_file(cert.to_pem, certname, settings[:certdir], "Certificate")
             next false unless save_file(cert.to_pem, certname, settings[:signeddir], "Certificate")
             next false unless save_keys(certname, settings, key)

--- a/lib/puppetserver/ca/action/import.rb
+++ b/lib/puppetserver/ca/action/import.rb
@@ -73,7 +73,8 @@ BANNER
 
         def import(loader, settings, signing_digest)
           ca = Puppetserver::Ca::LocalCertificateAuthority.new(signing_digest, settings)
-          master_key, master_cert = ca.create_master_cert(loader.key, loader.certs.first)
+          ca.load_ssl_components(loader)
+          master_key, master_cert = ca.create_master_cert
           return ca.errors if ca.errors.any?
 
           FileSystem.ensure_dirs([settings[:ssldir],

--- a/lib/puppetserver/ca/local_certificate_authority.rb
+++ b/lib/puppetserver/ca/local_certificate_authority.rb
@@ -1,5 +1,6 @@
 require 'puppetserver/ca/host'
 require 'puppetserver/ca/utils/file_system'
+require 'puppetserver/ca/x509_loader'
 
 require 'openssl'
 

--- a/lib/puppetserver/ca/local_certificate_authority.rb
+++ b/lib/puppetserver/ca/local_certificate_authority.rb
@@ -46,7 +46,13 @@ module Puppetserver
         @errors = []
 
         if ssl_assets_exist?
-          @cert, @key, @crl = load_ssl_assets
+          loader = Puppetserver::Ca::X509Loader.new(@settings[:cacert], @settings[:cakey], @settings[:cacrl])
+          if loader.errors.empty?
+            load_ssl_components(loader)
+          else
+            @errors += loader.errors
+            @errors << "CA not initialized. Please set up your CA before attempting to generate certs offline."
+          end
         end
       end
 
@@ -56,18 +62,10 @@ module Puppetserver
           File.exist?(@settings[:cacrl])
       end
 
-      def load_ssl_assets(settings=@settings)
-        loader = Puppetserver::Ca::X509Loader.new(@settings[:cacert], @settings[:cakey], @settings[:cacrl])
-        if loader.errors.empty?
-          cert = loader.certs.first
-          key = loader.key
-          crl = loader.crls.first
-          return cert, key, crl
-        else
-          @errors += loader.errors
-          @errors << "CA not initialized. Please set up your CA before attempting to generate certs offline."
-          nil
-        end
+      def load_ssl_components(loader)
+          @cert = loader.certs.first
+          @key = loader.key
+          @crl = loader.crls.first
       end
 
       def errors
@@ -103,7 +101,7 @@ module Puppetserver
         time.strftime('%Y-%m-%dT%H:%M:%S%Z')
       end
 
-      def create_master_cert(ca_key, ca_cert)
+      def create_master_cert
         master_cert = nil
         master_key = @host.create_private_key(@settings[:keylength],
                                               @settings[:hostprivkey],
@@ -116,17 +114,17 @@ module Puppetserver
             alt_names = @settings[:subject_alt_names]
           end
 
-          master_cert = sign_authorized_cert(ca_key, ca_cert, master_csr, alt_names)
+          master_cert = sign_authorized_cert(master_csr, alt_names)
         end
 
         return master_key, master_cert
       end
 
-      def sign_authorized_cert(int_key, int_cert, csr, alt_names = '')
+      def sign_authorized_cert(csr, alt_names = '')
         cert = OpenSSL::X509::Certificate.new
         cert.public_key = csr.public_key
         cert.subject = csr.subject
-        cert.issuer = int_cert.subject
+        cert.issuer = @cert.subject
         cert.version = 2
         cert.serial = next_serial(@settings[:serial])
         cert.not_before = CERT_VALID_FROM
@@ -134,14 +132,14 @@ module Puppetserver
 
         return unless add_custom_extensions(cert)
 
-        ef = extension_factory_for(int_cert, cert)
+        ef = extension_factory_for(@cert, cert)
         add_authorized_extensions(cert, ef)
 
         if !alt_names.empty?
           add_subject_alt_names_extension(alt_names, cert, ef)
         end
 
-        cert.sign(int_key, @digest)
+        cert.sign(@key, @digest)
 
         cert
       end
@@ -227,12 +225,12 @@ module Puppetserver
       end
 
       def create_intermediate_cert(root_key, root_cert)
-        int_key = @host.create_private_key(@settings[:keylength])
-        int_csr = @host.create_csr(name: @settings[:ca_name], key: int_key)
-        int_cert = sign_intermediate(root_key, root_cert, int_csr)
-        int_crl = create_crl_for(int_cert, int_key)
+        @key = @host.create_private_key(@settings[:keylength])
+        int_csr = @host.create_csr(name: @settings[:ca_name], key: @key)
+        @cert = sign_intermediate(root_key, root_cert, int_csr)
+        @crl = create_crl_for(@cert, @key)
 
-        return int_key, int_cert, int_crl
+        return nil
       end
 
       def sign_intermediate(ca_key, ca_cert, csr)

--- a/spec/puppetserver/ca/local_certificate_authority_spec.rb
+++ b/spec/puppetserver/ca/local_certificate_authority_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
     context "without a csr_attributes file" do
       it "adds only MA extensions to the csr" do
         root_key, root_cert, root_crl = subject.create_root_cert
-        int_key, int_cert, int_crl = subject.create_intermediate_cert(root_key, root_cert)
+        subject.create_intermediate_cert(root_key, root_cert)
 
-        _, cert = subject.create_master_cert(int_key, int_cert)
+        _, cert = subject.create_master_cert
         expect(cert.extensions.count).to eq(8)
       end
     end
@@ -79,9 +79,9 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
 
       it "adds extensions from csr_attributes yaml to the csr" do
         root_key, root_cert, root_crl = subject.create_root_cert
-        int_key, int_cert, int_crl = subject.create_intermediate_cert(root_key, root_cert)
+        subject.create_intermediate_cert(root_key, root_cert)
 
-        _, cert = subject.create_master_cert(int_key, int_cert)
+        _, cert = subject.create_master_cert
         expect(cert.extensions.count).to eq(10)
       end
     end
@@ -90,13 +90,13 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
   describe "#sign_authorized_cert" do
     it "has the special auth extension" do
       root_key, root_cert, root_crl = subject.create_root_cert
-      int_key, int_cert, int_crl = subject.create_intermediate_cert(root_key, root_cert)
+      subject.create_intermediate_cert(root_key, root_cert)
 
       host = Puppetserver::Ca::Host.new(Puppetserver::Ca::Utils::SigningDigest.new.digest)
       private_key = host.create_private_key(settings[:keylength])
       csr = host.create_csr(name: "foo", key: private_key)
 
-      cert = subject.sign_authorized_cert(int_key, int_cert, csr)
+      cert = subject.sign_authorized_cert(csr)
       auth_ext = cert.extensions.find do |ext|
         ext.oid == "1.3.6.1.4.1.34380.1.3.39"
       end
@@ -105,13 +105,13 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
 
     it "does not add default subject alt names" do
       root_key, root_cert, root_crl = subject.create_root_cert
-      int_key, int_cert, int_crl = subject.create_intermediate_cert(root_key, root_cert)
+      subject.create_intermediate_cert(root_key, root_cert)
 
       host = Puppetserver::Ca::Host.new(Puppetserver::Ca::Utils::SigningDigest.new.digest)
       private_key = host.create_private_key(settings[:keylength])
       csr = host.create_csr(name: "foo", key: private_key)
 
-      cert = subject.sign_authorized_cert(int_key, int_cert, csr)
+      cert = subject.sign_authorized_cert(csr)
       san = cert.extensions.find do |ext|
         ext.oid == "subjectAltNames"
       end
@@ -120,13 +120,13 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
 
     it "adds subject alt names if specified" do
       root_key, root_cert, root_crl = subject.create_root_cert
-      int_key, int_cert, int_crl = subject.create_intermediate_cert(root_key, root_cert)
+      subject.create_intermediate_cert(root_key, root_cert)
 
       host = Puppetserver::Ca::Host.new(Puppetserver::Ca::Utils::SigningDigest.new.digest)
       private_key = host.create_private_key(settings[:keylength])
       csr = host.create_csr(name: "foo", key: private_key)
 
-      cert = subject.sign_authorized_cert(int_key, int_cert, csr, "DNS:bar,IP:123.0.0.5")
+      cert = subject.sign_authorized_cert(csr, "DNS:bar,IP:123.0.0.5")
       san = cert.extensions.find do |ext|
         ext.oid == "subjectAltName"
       end

--- a/spec/puppetserver/ca/local_certificate_authority_spec.rb
+++ b/spec/puppetserver/ca/local_certificate_authority_spec.rb
@@ -1,22 +1,54 @@
 require 'puppetserver/ca/local_certificate_authority'
+require 'puppetserver/ca/config/puppet'
 
+require 'utils/ssl'
 require 'puppetserver/ca/utils/signing_digest'
 
 RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
+  include Utils::SSL
 
+  let(:tmpdir) { Dir.mktmpdir }
   let(:settings) {
-    { :ca_ttl => 157680000,
-      :ca_name => 'bulla2',
-      :subject_alt_names => '',
-      :root_ca_name => 'bulla',
-      :certname => 'ulla',
-      :keylength => 512,
-      :hostprivkey => '$privatekeydir/$certname.pem',
-      :hostpubkey => '$publickeydir/$certname.pem',
-      :csr_attributes => '$confdir/csr_attributes.yaml',
-      :serial => '$cadir/serial' } }
+    with_ca_in(tmpdir) do |config, confdir|
+      return Puppetserver::Ca::Config::Puppet.new(config).load({confdir: confdir })
+    end
+  }
+
+  after(:each) do
+    FileUtils.rm_rf(tmpdir)
+  end
 
   let(:subject) { Puppetserver::Ca::LocalCertificateAuthority.new(OpenSSL::Digest::SHA256.new, settings) }
+
+  describe '#initialize' do
+    it 'loads ssl assets if they exist' do
+      expect(subject.cert).to be_kind_of(OpenSSL::X509::Certificate)
+      expect(subject.key).to be_kind_of(OpenSSL::PKey::RSA)
+      expect(subject.crl).to be_kind_of(OpenSSL::X509::CRL)
+    end
+
+    context 'when an ssl asset is missing' do
+      let(:settings) {
+        with_ca_in(Dir.mktmpdir) do |config|
+          return Puppetserver::Ca::Config::Puppet.new(config).load({cacert: '/some/rando/path'})
+        end
+      }
+      it 'does not load ssl assets if they are not found' do
+        expect(subject.cert).to be_nil
+        expect(subject.key).to be_nil
+        expect(subject.crl).to be_nil
+      end
+    end
+
+    context 'with a malformed certificate' do
+      before do
+        File.write(settings[:cacert], 'This_is_not_a_valid_cert')
+      end
+      it 'adds an error to the ca object' do
+        expect(subject.errors).not_to be_empty
+      end
+    end
+  end
 
   describe "#create_master_cert" do
     context "without a csr_attributes file" do
@@ -41,7 +73,7 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
 
       before(:each) do
         allow(File).to receive(:exist?).and_return(true)
-        allow(File).to receive(:exist?).with('$cadir/serial').and_return(false)
+        allow(File).to receive(:exist?).with(/serial/).and_return(false)
         allow(YAML).to receive(:load_file).and_return(csr_attributes)
       end
 


### PR DESCRIPTION
Before this change, no state about the local CA was kept in memory; this
change introduces instance variables for cert, key, and crl to the class
and allows for them to be read from an object if the necessary files
existed.