### PR TITLE
(SERVER-2401) Handle new exceptions when checking CA status

### DIFF
--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -75,8 +75,8 @@ BANNER
               parsed['subject-alt-names'] = sans
             end
             opts.on('--ca-client',
-                    'Whether this cert will be used to request CA actions.\
-                    Causes the cert to be generated offline.') do |ca_client|
+                    'Whether this cert will be used to request CA actions.',
+                    'Causes the cert to be generated offline.') do |ca_client|
               parsed['ca-client'] = true
             end
           end

--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -168,9 +168,12 @@ BANNER
               end
             end
             true
-          rescue Errno::ECONNREFUSED => e
-            # Couldn't make a connection
-            false
+          rescue Puppetserver::Ca::ConnectionFailed => e
+            if e.wrapped.is_a? Errno::ECONNREFUSED
+              return false
+            else
+              raise e
+            end
           end
         end
 

--- a/lib/puppetserver/ca/errors.rb
+++ b/lib/puppetserver/ca/errors.rb
@@ -1,6 +1,13 @@
 module Puppetserver
   module Ca
-    class Error < StandardError; end
+    class Error < StandardError
+      attr_reader :wrapped
+
+      def wrap(ex)
+        @wrapped = ex
+      end
+    end
+
     class FileNotFound < Error; end
     class InvalidX509Object < Error; end
     class ConnectionFailed < Error; end

--- a/lib/puppetserver/ca/errors.rb
+++ b/lib/puppetserver/ca/errors.rb
@@ -1,6 +1,13 @@
 module Puppetserver
   module Ca
     class Error < StandardError
+      def self.create(ex, msg)
+        created = new(msg)
+        created.wrap(ex)
+
+        created
+      end
+
       attr_reader :wrapped
 
       def wrap(ex)

--- a/lib/puppetserver/ca/utils/http_client.rb
+++ b/lib/puppetserver/ca/utils/http_client.rb
@@ -58,9 +58,11 @@ module Puppetserver
                             cert: @cert, key: @key,
                             &request)
           rescue StandardError => e
-            raise ConnectionFailed.new(
+            ex = ConnectionFailed.new(
               "Failed connecting to #{url.full_url}\n" +
               "  Root cause: #{e.message}")
+            ex.wrap(e)
+            raise ex
           end
         end
 
@@ -70,12 +72,16 @@ module Puppetserver
           begin
             content = File.read(path)
             block.call(content)
-          rescue Errno::ENOENT
-            raise FileNotFound.new("Could not find '#{setting}' at '#{path}'")
+          rescue Errno::ENOENT => e
+            ex = FileNotFound.new("Could not find '#{setting}' at '#{path}'")
+            ex.wrap(e)
+            raise ex
           rescue OpenSSL::OpenSSLError => e
-            raise InvalidX509Object.new(
+            ex = InvalidX509Object.new(
               "Could not parse '#{setting}' at '#{path}'.\n" +
               "  OpenSSL returned: #{e.message}")
+            ex.wrap(e)
+            raise ex
           end
        end
 

--- a/lib/puppetserver/ca/utils/http_client.rb
+++ b/lib/puppetserver/ca/utils/http_client.rb
@@ -58,11 +58,9 @@ module Puppetserver
                             cert: @cert, key: @key,
                             &request)
           rescue StandardError => e
-            ex = ConnectionFailed.new(
-              "Failed connecting to #{url.full_url}\n" +
-              "  Root cause: #{e.message}")
-            ex.wrap(e)
-            raise ex
+            raise ConnectionFailed.create(e,
+                    "Failed connecting to #{url.full_url}\n" +
+                    "  Root cause: #{e.message}")
           end
         end
 
@@ -73,15 +71,13 @@ module Puppetserver
             content = File.read(path)
             block.call(content)
           rescue Errno::ENOENT => e
-            ex = FileNotFound.new("Could not find '#{setting}' at '#{path}'")
-            ex.wrap(e)
-            raise ex
+            raise FileNotFound.create(e,
+                    "Could not find '#{setting}' at '#{path}'")
+
           rescue OpenSSL::OpenSSLError => e
-            ex = InvalidX509Object.new(
-              "Could not parse '#{setting}' at '#{path}'.\n" +
-              "  OpenSSL returned: #{e.message}")
-            ex.wrap(e)
-            raise ex
+            raise InvalidX509Object.create(e,
+                    "Could not parse '#{setting}' at '#{path}'.\n" +
+                    "  OpenSSL returned: #{e.message}")
           end
        end
 

--- a/spec/puppetserver/ca/action/generate_spec.rb
+++ b/spec/puppetserver/ca/action/generate_spec.rb
@@ -5,6 +5,7 @@ require 'utils/http'
 require 'tmpdir'
 
 require 'puppetserver/ca/action/generate'
+require 'puppetserver/ca/errors'
 require 'puppetserver/ca/logger'
 require 'puppetserver/ca/utils/http_client'
 
@@ -313,6 +314,29 @@ RSpec.describe Puppetserver::Ca::Action::Generate do
         to receive(:with_connection).and_yield(connection)
       allow_any_instance_of(Puppetserver::Ca::Utils::HttpClient).
         to receive(:make_store)
+    end
+
+    it 'returns false if nothing is listening on the port' do
+      orig = Errno::ECONNREFUSED.new
+      raised = Puppetserver::Ca::ConnectionFailed.new('uncaught exception')
+      raised.wrap(orig)
+      allow(Puppetserver::Ca::Utils::HttpClient).
+        to receive(:new).and_raise(raised)
+
+      settings = {ca_server: 'foo.com', ca_port: 8080}
+      expect(subject.check_server_online(settings)).to be false
+    end
+
+    it 'dies if there are other issues with the connection' do
+      orig = StandardError.new
+      raised = Puppetserver::Ca::ConnectionFailed.new('uncaught exception')
+      raised.wrap(orig)
+      allow(Puppetserver::Ca::Utils::HttpClient).
+        to receive(:new).and_raise(raised)
+
+      settings = {ca_server: 'foo.com', ca_port: 8080}
+      expect{ subject.check_server_online(settings) }.
+        to raise_error(Puppetserver::Ca::ConnectionFailed)
     end
 
     it "refuses to generate a cert if the server is running" do

--- a/spec/puppetserver/ca/action/generate_spec.rb
+++ b/spec/puppetserver/ca/action/generate_spec.rb
@@ -317,22 +317,24 @@ RSpec.describe Puppetserver::Ca::Action::Generate do
     end
 
     it 'returns false if nothing is listening on the port' do
-      orig = Errno::ECONNREFUSED.new
-      raised = Puppetserver::Ca::ConnectionFailed.new('uncaught exception')
-      raised.wrap(orig)
       allow(Puppetserver::Ca::Utils::HttpClient).
-        to receive(:new).and_raise(raised)
+        to receive(:new).
+        and_raise(
+          Puppetserver::Ca::ConnectionFailed.create(
+            Errno::ECONNREFUSED.new,
+            'uncaught exception'))
 
       settings = {ca_server: 'foo.com', ca_port: 8080}
       expect(subject.check_server_online(settings)).to be false
     end
 
     it 'dies if there are other issues with the connection' do
-      orig = StandardError.new
-      raised = Puppetserver::Ca::ConnectionFailed.new('uncaught exception')
-      raised.wrap(orig)
       allow(Puppetserver::Ca::Utils::HttpClient).
-        to receive(:new).and_raise(raised)
+        to receive(:new).
+        and_raise(
+          Puppetserver::Ca::ConnectionFailed.create(
+            StandardError.new,
+            'uncaught exception'))
 
       settings = {ca_server: 'foo.com', ca_port: 8080}
       expect{ subject.check_server_online(settings) }.

--- a/spec/puppetserver/ca/errors_spec.rb
+++ b/spec/puppetserver/ca/errors_spec.rb
@@ -8,8 +8,8 @@ require 'puppetserver/ca/logger'
 
 RSpec.describe Puppetserver::Ca::Error do
   it 'can wrap an exception' do
-    ex = Puppetserver::Ca::Error.new('wrapper exception')
     orig = StandardError.new('wrapped exception')
+    ex = Puppetserver::Ca::Error.create(orig, 'wrapper exception')
     expect {
       ex.wrap(orig)
       expect(ex.wrapped).to be(orig)

--- a/spec/puppetserver/ca/errors_spec.rb
+++ b/spec/puppetserver/ca/errors_spec.rb
@@ -1,7 +1,24 @@
 require 'spec_helper'
 
-RSpec.describe Puppetserver::Ca::Errors do
+require 'puppetserver/ca/errors'
+require 'puppetserver/ca/logger'
 
+# NOTE: There's two top level describes here, one for custom error
+# functionality and one for the Errors help module.
+
+RSpec.describe Puppetserver::Ca::Error do
+  it 'can wrap an exception' do
+    ex = Puppetserver::Ca::Error.new('wrapper exception')
+    orig = StandardError.new('wrapped exception')
+    expect {
+      ex.wrap(orig)
+      expect(ex.wrapped).to be(orig)
+    }.not_to raise_error
+  end
+
+end
+
+RSpec.describe Puppetserver::Ca::Errors do
   describe 'handle with usage' do
     let(:stdout) { StringIO.new }
     let(:stderr) { StringIO.new }


### PR DESCRIPTION
From 03da206 which implements most of this functionality:
```
Previously, we were catching ECONNREFUSED to determine if the server was
up. When we moved to custom error classes we no longer raise an
ECONNREFUSED, instead raising ConnectionFailed in it (and many other
potential exceptions) place.

So we should now be rescuing ConnectionFailed, but we only want to
swallow exceptions that originated from ECONNREFUSED, re-raising
ConnectionFaileds that originate from other exceptions.

To do so we add the ability to wrap an exception in our custom Error
class and update appropriate places where we were raising.
```