### PR TITLE
(SERVER-2478) Do not create an `infra_serials` file

### DIFF
--- a/lib/puppetserver/ca/action/enable.rb
+++ b/lib/puppetserver/ca/action/enable.rb
@@ -26,8 +26,8 @@ Description:
     Creates auxiliary files necessary to use the infrastructure-only CRL.
     Assumes the existence of an `infra_inventory.txt` file in the CA
     directory listing the certnames of the infrastructure nodes in the
-    Puppet installation. Generates the `infra_serials` file and the empty
-    CRL to be populated with revoked infrastructure nodes.
+    Puppet installation. Generates the the empty CRL to be populated with
+    revoked infrastructure nodes.
 
 Options:
 BANNER
@@ -67,13 +67,10 @@ ERR
             return [error]
           end
 
-          serial_file = File.join(settings[:cadir], 'infra_serials')
           infra_crl = File.join(settings[:cadir], 'infra_crl.pem')
 
-          file_errors = check_for_existing_infra_files([serial_file, infra_crl])
+          file_errors = check_for_existing_infra_files(infra_crl)
           return file_errors if !file_errors.empty?
-
-          FileSystem.write_file(serial_file, '', 0644)
 
           errors = create_infra_crl_chain(settings)
           return errors if !errors.empty?

--- a/spec/puppetserver/ca/action/enable_spec.rb
+++ b/spec/puppetserver/ca/action/enable_spec.rb
@@ -51,11 +51,10 @@ RSpec.describe Puppetserver::Ca::Action::Enable do
       end
     end
 
-    it 'generates auxiliary infra CRL files' do
+    it 'generates infra CRL' do
       Dir.mktmpdir do |tmpdir|
         with_ca_in tmpdir do |conf, ca_dir|
           inventory = File.join(ca_dir, 'infra_inventory.txt')
-          serials = File.join(ca_dir, 'infra_serials')
           infra_crl = File.join(ca_dir, 'infra_crl.pem')
 
           File.open(inventory, 'w') do |f|
@@ -63,7 +62,6 @@ RSpec.describe Puppetserver::Ca::Action::Enable do
           end
           exit_code = subject.run({ 'config'   => conf,
                                     'infracrl' => true })
-          expect(File.exist?(serials)).to be true
           expect(File.exist?(infra_crl)).to be true
         end
       end
@@ -73,7 +71,6 @@ RSpec.describe Puppetserver::Ca::Action::Enable do
       Dir.mktmpdir do |tmpdir|
         with_ca_in tmpdir do |conf, ca_dir|
           inventory = File.join(ca_dir, 'infra_inventory.txt')
-          serials = File.join(ca_dir, 'infra_serials')
           infra_crl = File.join(ca_dir, 'infra_crl.pem')
 
           File.open(inventory, 'w') do |f|
@@ -81,7 +78,6 @@ RSpec.describe Puppetserver::Ca::Action::Enable do
           end
           exit_code = subject.run({ 'config'   => conf,
                                     'infracrl' => true })
-          expect(File.exist?(serials)).to be true
           expect(File.exist?(infra_crl)).to be true
           expect(exit_code).to eq(0)
 


### PR DESCRIPTION
Puppet Server will always generate an `infra_serials` file based on the
contents of `infra_inventory` on startup when the Infra CRL is enabled.
Therefore, the gem doesn't need to try to create it and doesn't need to
block if it is already present. This will help with some weird upgrade
scenarios where an inventory and infra_serials file are present, but the
CRL itself is not.