### PR TITLE
(SERVER-2465) Find signing cert and crl based on private key

### DIFF
--- a/lib/puppetserver/ca/local_certificate_authority.rb
+++ b/lib/puppetserver/ca/local_certificate_authority.rb
@@ -64,10 +64,10 @@ module Puppetserver
 
       def load_ssl_components(loader)
         @cert_bundle = loader.certs
-        @cert = loader.certs.first
         @key = loader.key
+        @cert = loader.cert
         @crl_chain = loader.crls
-        @crl = loader.crls.first
+        @crl = loader.crl
       end
 
       def errors

--- a/spec/puppetserver/ca/action/import_spec.rb
+++ b/spec/puppetserver/ca/action/import_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Puppetserver::Ca::Action::Import do
           exit_code = subject.run({ 'cert-bundle' => bundle,
                                     'private-key'=> key,
                                     'crl-chain' => chain })
-          expect(stderr.string).to include('Private key and certificate do not match')
+          expect(stderr.string).to include('Could not find certificate matching private key')
         end
       end
     end
@@ -184,7 +184,7 @@ RSpec.describe Puppetserver::Ca::Action::Import do
           exit_code = subject.run({ 'cert-bundle' => bundle,
                                     'private-key'=> key,
                                     'crl-chain' => chain })
-          expect(stderr.string).to include('Leaf CRL was not issued by leaf certificate')
+          expect(stderr.string).to include('Could not find CRL issued by CA certificate')
         end
       end
     end

--- a/spec/utils/ssl.rb
+++ b/spec/utils/ssl.rb
@@ -180,16 +180,16 @@ module Utils
       leaf_cert = create_cert(leaf_key, 'bar', root_key, root_cert)
 
       File.open(bundle_file, 'w') do |f|
-        f.puts leaf_cert.to_pem
         f.puts root_cert.to_pem
+        f.puts leaf_cert.to_pem
       end
 
       root_crl = create_crl(root_cert, root_key)
       leaf_crl = create_crl(leaf_cert, leaf_key)
 
       File.open(chain_file, 'w') do |f|
-        f.puts leaf_crl.to_pem
         f.puts root_crl.to_pem
+        f.puts leaf_crl.to_pem
       end
 
 


### PR DESCRIPTION
Instead of requiring the signing certificate to be first in the certificate
bundle, find the certificate that matches the private key for the CA, and find
the CRL that is issued by that certificate.