### PR TITLE
(SERVER-2559) Check CA for errors before enabling infra crl

### DIFF
--- a/lib/puppetserver/ca/action/enable.rb
+++ b/lib/puppetserver/ca/action/enable.rb
@@ -97,8 +97,9 @@ MSG
           return signer.errors if signer.errors.any?
 
           ca = LocalCertificateAuthority.new(signer.digest, settings)
-          infra_crl = ca.create_crl_for(ca.cert, ca.key)
           return ca.errors if ca.errors.any?
+
+          infra_crl = ca.create_crl_for(ca.cert, ca.key)
 
           # Drop the full leaf CRL from the chain
           crl_chain = ca.crl_chain.drop(1)


### PR DESCRIPTION
This commit updates `puppetserver ca enable --infracrl` to check the CA
state for errors before attempting to generate the infrastructure CRL.
Prior to this commit, errors encountered when loading the CA state would
cause instance variables such as the certificate and private key to be
unset. This would result in CRL creation failing due to unexpected `nil`
values without providing clear messaging as to the root cause of the
problem.