### PR TITLE
(SERVER-2549) Add generate-csr action

### DIFF
--- a/lib/puppetserver/ca/action/generate_csr.rb
+++ b/lib/puppetserver/ca/action/generate_csr.rb
@@ -1,0 +1,123 @@
+require 'optparse'
+
+require 'puppetserver/ca/config/puppet'
+require 'puppetserver/ca/errors'
+require 'puppetserver/ca/local_certificate_authority'
+require 'puppetserver/ca/utils/cli_parsing'
+require 'puppetserver/ca/utils/file_system'
+require 'puppetserver/ca/utils/signing_digest'
+
+module Puppetserver
+  module Ca
+    module Action
+      class GenerateCsr
+        include Puppetserver::Ca::Utils
+
+        SUMMARY = 'Generate a CSR for an intermediate signing CA cert'
+        BANNER = <<-BANNER
+Usage:
+  puppetserver ca generate-csr [--help]
+  puppetserver ca generate-csr --output-dir PATH [--config PATH] [--ca-name NAME]
+
+Description:
+  Setup a root and intermediate signing CA for Puppet Server
+  and store generated CA keys, certs, crls, and associated
+  master related files on disk.
+
+Options:
+        BANNER
+
+        def initialize(logger)
+          @logger = logger
+        end
+
+        def run(input)
+          # Validate config_path provided
+          config_path = input['config']
+          if config_path
+            errors = FileSystem.validate_file_paths(config_path)
+            return 1 if Errors.handle_with_usage(@logger, errors)
+          end
+
+          # Load, resolve, and validate puppet config settings
+          settings_overrides = {}
+          settings_overrides[:ca_name] = input['ca-name'] unless input['ca-name'].empty?
+
+          puppet = Config::Puppet.new(config_path)
+          puppet.load(settings_overrides)
+          return 1 if Errors.handle_with_usage(@logger, puppet.errors)
+
+          # Load most secure signing digest we can for cers/crl/csr signing.
+          signer = SigningDigest.new
+          return 1 if Errors.handle_with_usage(@logger, signer.errors)
+
+          # Generate intermediate ca and put the results in the specified output directory
+          generate_csr(puppet.settings, signer.digest, input['output-dir'])
+          return 0
+        end
+
+        def generate_csr(settings, signing_digest, dir)
+          ca = Puppetserver::Ca::LocalCertificateAuthority.new(signing_digest, settings)
+
+          key, csr = ca.create_intermediate_csr
+
+          write_generated_files(key, csr, dir)
+        end
+
+        def write_generated_files(key, csr, dir)
+          FileSystem.write_file(File.join(dir, 'ca.key'), key.to_s, 0640)
+          FileSystem.write_file(File.join(dir, 'ca.csr'), csr.to_s, 0640)
+        end
+
+        def check_for_existing_ssl_files(dir)
+          files = [ File.join(dir, 'ca.key'), File.join(dir, 'ca.csr')]
+          errors = Puppetserver::Ca::Utils::FileSystem.check_for_existing_files(files)
+          if !errors.empty?
+            errors << 'Please delete these files if you want to generate a CSR'
+          end
+
+          errors
+        end
+
+        def parse(cli_args)
+          results = {}
+          parser = self.class.parser(results)
+          errors = CliParsing.parse_with_errors(parser, cli_args)
+
+          if results['output-dir'].nil? || results['output-dir'].empty?
+            errors << '    Must specify an output directory to store generated files in'
+          elsif !Dir.exist?(results['output-dir'])
+            errors << '    Specified output directory must exist'
+          else
+            errors.concat(check_for_existing_ssl_files(results['output-dir']))
+          end
+
+          errors_were_handled = Errors.handle_with_usage(@logger, errors, parser.help)
+          exit_code = errors_were_handled ? 1 : nil
+          return results, exit_code
+        end
+
+        def self.parser(parsed = {})
+          parsed['ca-name'] = ''
+          OptionParser.new do |opts|
+            opts.banner = BANNER
+            opts.on('--help', 'Display this command-specific help output') do |help|
+              parsed['help'] = true
+            end
+            opts.on('--output-dir PATH',
+                    'Path to directory to store generated key and csr in') do |dir|
+              parsed['output-dir'] = dir
+            end
+            opts.on('--config CONF', 'Path to puppet.conf') do |conf|
+              parsed['config'] = conf
+            end
+            opts.on('--ca-name NAME',
+                    'Common name to use for the CA signing cert') do |name|
+              parsed['ca-name'] = name
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/puppetserver/ca/cli.rb
+++ b/lib/puppetserver/ca/cli.rb
@@ -2,6 +2,7 @@ require 'optparse'
 
 require 'puppetserver/ca/action/clean'
 require 'puppetserver/ca/action/generate'
+require 'puppetserver/ca/action/generate_csr'
 require 'puppetserver/ca/action/import'
 require 'puppetserver/ca/action/enable'
 require 'puppetserver/ca/action/list'
@@ -28,6 +29,7 @@ BANNER
         'import'   => Action::Import,
         'setup'    => Action::Setup,
         'enable' => Action::Enable,
+        'generate-csr' => Action::GenerateCsr,
       }
 
       MAINT_ACTIONS = {

--- a/lib/puppetserver/ca/local_certificate_authority.rb
+++ b/lib/puppetserver/ca/local_certificate_authority.rb
@@ -235,6 +235,13 @@ module Puppetserver
         return nil
       end
 
+      def create_intermediate_csr
+        key = @host.create_private_key(@settings[:keylength])
+        csr = @host.create_csr(name: @settings[:ca_name], key: key)
+
+        return [key, csr]
+      end
+
       def sign_intermediate(ca_key, ca_cert, csr)
         cert = OpenSSL::X509::Certificate.new
 

--- a/spec/puppetserver/ca/action/generate_csr_spec.rb
+++ b/spec/puppetserver/ca/action/generate_csr_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+require 'utils/ssl'
+
+require 'tmpdir'
+
+require 'puppetserver/ca/action/generate_csr'
+require 'puppetserver/ca/errors'
+require 'puppetserver/ca/logger'
+
+RSpec.describe Puppetserver::Ca::Action::GenerateCsr do
+  include Utils::SSL
+
+  let(:stdout) {StringIO.new}
+  let(:stderr) {StringIO.new}
+  let(:logger) {Puppetserver::Ca::Logger.new(:info, stdout, stderr)}
+
+  subject {Puppetserver::Ca::Action::GenerateCsr.new(logger)}
+
+  describe 'flags' do
+    it 'takes a single output directory' do
+      Dir.mktmpdir do |tmpdir|
+        result, maybe_code = subject.parse(['--output-dir', tmpdir])
+        expect(maybe_code).to eq(nil)
+        expect(result['output-dir']).to eq(tmpdir)
+      end
+    end
+
+    describe 'flags' do
+      it 'takes a single CA name' do
+        Dir.mktmpdir do |tmpdir|
+          result, maybe_code = subject.parse(['--ca-name', 'foo.example.com',
+                                              '--output-dir', tmpdir])
+          expect(maybe_code).to eq(nil)
+          expect(result['ca-name']).to eq('foo.example.com')
+        end
+      end
+
+      it 'takes a custom puppet.conf location' do
+        Dir.mktmpdir do |tmpdir|
+          result, maybe_code = subject.parse(['--ca-name', 'foo',
+                                              '--config', '/dev/tcp/example.com',
+                                              '--output-dir', tmpdir])
+          expect(maybe_code).to be(nil)
+          expect(result['config']).to eq('/dev/tcp/example.com')
+        end
+      end
+    end
+  end
+
+  describe 'validation' do
+    it 'fails with no output directory' do
+      result, maybe_code = subject.parse([])
+      expect(maybe_code).to eq(1)
+      expect(stderr.string).to include('Must specify an output directory to store generated files in')
+    end
+
+    it 'fails with nonexistent output directory' do
+      result, maybe_code = subject.parse(['--output-dir', '/fake/fake/foo/bar/does/not/exist'])
+      expect(maybe_code).to eq(1)
+      expect(stderr.string).to include('Specified output directory must exist')
+    end
+
+    it 'fails if files to write already exist' do
+      Dir.mktmpdir do |tmpdir|
+        files = [File.join(tmpdir, 'ca.key'), File.join(tmpdir, 'ca.csr')]
+        files.each {|file| IO.write(file, '')}
+        result, maybe_code = subject.parse(['--output-dir', tmpdir])
+        expect(maybe_code).to eq(1)
+        expect(stderr.string).to include('ca.key')
+        expect(stderr.string).to include('ca.csr')
+        expect(stderr.string).to include('Please delete these files if you want to generate a CSR')
+      end
+    end
+  end
+
+  describe 'csr generation' do
+    it 'creates the appropriate files' do
+      Dir.mktmpdir do |output_tmpdir|
+        Dir.mktmpdir do |puppet_tmpdir|
+          with_temp_dirs puppet_tmpdir do |config|
+            code = subject.run({'ca-name' => 'foo.example.com',
+                                'config' => config,
+                                'output-dir' => output_tmpdir})
+            expected_name = OpenSSL::X509::Name.new([["CN", 'foo.example.com']])
+            expect(code).to eq(0)
+            expect(File).to exist(File.join(output_tmpdir, 'ca.csr'))
+            expect(File).to exist(File.join(output_tmpdir, 'ca.key'))
+            csr = OpenSSL::X509::Request.new(File.read(File.join(output_tmpdir, 'ca.csr')))
+            key = OpenSSL::PKey::RSA.new(File.read(File.join(output_tmpdir, 'ca.key')))
+            expect(csr).not_to be_nil
+            expect(key).not_to be_nil
+            expect(csr).to be_kind_of(OpenSSL::X509::Request)
+            expect(key).to be_kind_of(OpenSSL::PKey::RSA)
+            expect(csr.subject).to eq(expected_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/puppetserver/ca/local_certificate_authority_spec.rb
+++ b/spec/puppetserver/ca/local_certificate_authority_spec.rb
@@ -133,4 +133,14 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
       expect(san.value).to eq("DNS:bar, IP Address:123.0.0.5")
     end
   end
+
+  describe "#create_intermediate_csr" do
+    it "returns a private key and csr" do
+      key, csr = subject.create_intermediate_csr
+      expected_name = OpenSSL::X509::Name.new([["CN", settings[:ca_name]]])
+      expect(key).to be_kind_of(OpenSSL::PKey::RSA)
+      expect(csr).to be_kind_of(OpenSSL::X509::Request)
+      expect(csr.subject).to eq(expected_name)
+    end
+  end
 end


### PR DESCRIPTION
This adds a new action, `generate-csr`, which can be used to generate a CSR and
private key for an intermediate CA. This CSR can then be signed by external PKI
infrastructure and then imported using the `import` action.

I just kind of picked a way to expose the functionality, but it should be pretty straightforward to either rename the command or move the functionality under an existing command.