### PR TITLE
(maint) Add executable to gemspec

### DIFF
--- a/puppetserver-ca.gemspec
+++ b/puppetserver-ca.gemspec
@@ -16,11 +16,13 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "facter", [">= 2.0.1", "< 4"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This makes it possible to run the executable with bundler from a git
checkout.