### PR TITLE
(SERVER-2589) Add a --certname option to `list` action

### DIFF
--- a/lib/puppetserver/ca/action/list.rb
+++ b/lib/puppetserver/ca/action/list.rb
@@ -89,7 +89,7 @@ Options:
         end
 
         def output_certs_by_state(requested, signed = [], revoked = [], missing = [])
-          if revoked.empty? && signed.empty? && requested.empty?
+          if revoked.empty? && signed.empty? && requested.empty? && missing.empty?
             @logger.inform "No certificates to list"
             return
           end

--- a/spec/puppetserver/ca/action/list_spec.rb
+++ b/spec/puppetserver/ca/action/list_spec.rb
@@ -39,5 +39,22 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
       expect(out.string).to match(/Signed Certificates:.*foo.*\(SHA256\).*three.*alt names:.*"DNS:foo", "DNS:bar".*/m)
       expect(out.string).to match(/Revoked Certificates:.*foobar.*\(SHA256\).*onetwo.*alt names:.*"DNS:foobar", "DNS:barfoo".*/m)
     end
+
+    it 'logs requested certs with --certs flag' do
+      allow(action).to receive(:get_all_certs).and_return(result)
+      exit_code = action.run({'certname' => ['foo','baz']})
+      expect(exit_code).to eq(0)
+      expect(out.string).to match(/Requested Certificates:.*baz.*\(SHA256\).*two.*alt names:.*"DNS:baz", "DNS:bar".*/m)
+      expect(out.string).to match(/Signed Certificates:.*foo.*\(SHA256\).*three.*alt names:.*"DNS:foo", "DNS:bar".*/m)
+      expect(out.string).to_not match(/Revoked Certificates:.*foobar.*\(SHA256\).*onetwo.*alt names:.*"DNS:foobar", "DNS:barfoo".*/m)
+    end
+
+    it 'errors when requested certs are missing with --certs flag' do
+      allow(action).to receive(:get_all_certs).and_return(result)
+      exit_code = action.run({'certname' => ['foo','fake']})
+      expect(exit_code).to eq(1)
+      expect(out.string).to match(/Signed Certificates:.*foo.*\(SHA256\).*three.*alt names:.*"DNS:foo", "DNS:bar".*/m)
+      expect(out.string).to match(/Missing Certificates:.*fake.*/m)
+    end
   end
 end

--- a/spec/puppetserver/ca/action/list_spec.rb
+++ b/spec/puppetserver/ca/action/list_spec.rb
@@ -49,7 +49,14 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
       expect(out.string).to_not match(/Revoked Certificates:.*foobar.*\(SHA256\).*onetwo.*alt names:.*"DNS:foobar", "DNS:barfoo".*/m)
     end
 
-    it 'errors when requested certs are missing with --certs flag' do
+    it 'logs a non-existent cert as missing when requested with --certs flag' do
+      allow(action).to receive(:get_all_certs).and_return(result)
+      exit_code = action.run({'certname' => ['fake']})
+      expect(exit_code).to eq(1)
+      expect(out.string).to match(/Missing Certificates:.*fake.*/m)
+    end
+
+    it 'errors when any requested certs are missing with --certs flag' do
       allow(action).to receive(:get_all_certs).and_return(result)
       exit_code = action.run({'certname' => ['foo','fake']})
       expect(exit_code).to eq(1)


### PR DESCRIPTION
The new --certname option on the list action behaves similiarly to how
the option operates on other actions, in this case by limiting the
output to the certnames specified, and causing the command to return a
non-zero exit code in the event a certname specified is not able to be
listed (because it is not present).

This brings `puppetserver ca list` closer to parity with older commands
such as `puppet cert list`.

Initial implementation is not performance optimized. It doesn't look
like the certificate_statuses API actually supports returning a filtered
list, so this commit is forced to filter the results of requesting all
certificate statuses.