### PR TITLE
(SERVER-2603) Read and write the serial file in hex

### DIFF
--- a/lib/puppetserver/ca/local_certificate_authority.rb
+++ b/lib/puppetserver/ca/local_certificate_authority.rb
@@ -93,7 +93,7 @@ module Puppetserver
 
       def next_serial(serial_file)
         if File.exist?(serial_file)
-          File.read(serial_file).to_i
+          File.read(serial_file).to_i(16)
         else
           1
         end
@@ -259,7 +259,7 @@ module Puppetserver
       end
 
       def update_serial_file(serial)
-        Puppetserver::Ca::Utils::FileSystem.write_file(@settings[:serial], serial, 0644)
+        Puppetserver::Ca::Utils::FileSystem.write_file(@settings[:serial], serial.to_s(16), 0644)
       end
     end
   end

--- a/spec/puppetserver/ca/local_certificate_authority_spec.rb
+++ b/spec/puppetserver/ca/local_certificate_authority_spec.rb
@@ -133,4 +133,17 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
       expect(san.value).to eq("DNS:bar, IP Address:123.0.0.5")
     end
   end
+  context "hex serial file" do
+    before do
+      File.write(settings[:serial], '01C')
+      allow(File).to receive(:exist?).and_return(true)
+    end
+    it "converts the hex serial to integer on read" do
+      expect(subject.next_serial(settings[:serial])).to eq(28)
+    end
+    it "converts the hex serial to integer on write" do
+      subject.update_serial_file(28)
+      expect(File.read(settings[:serial])).to match(/1c/i)
+    end
+  end
 end


### PR DESCRIPTION
Prior to this PR, the serial file was converted to an integer from a string which would incorrectly round alphabetic digits. This commit ensures that reading and writing the serial file in hex format.