### PR TITLE
(maint) Allow Bundler version to float

### DIFF
--- a/puppetserver-ca.gemspec
+++ b/puppetserver-ca.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "facter", [">= 2.0.1", "< 4"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This commit changes the Bundler version constraint in the gemspec file
from `~> 1.16` to `>= 1.16` and allows Bundler 2.x to be used.