### PR TITLE
(SERVER-2552) Initialize leaf CRL during import

### DIFF
--- a/lib/puppetserver/ca/action/import.rb
+++ b/lib/puppetserver/ca/action/import.rb
@@ -71,7 +71,7 @@ BANNER
 
         def import(loader, settings, signing_digest)
           ca = Puppetserver::Ca::LocalCertificateAuthority.new(signing_digest, settings)
-          ca.load_ssl_components(loader)
+          ca.initialize_ssl_components(loader)
           master_key, master_cert = ca.create_master_cert
           return ca.errors if ca.errors.any?
 


### PR DESCRIPTION
This commit updates the `puppetserver ca import` command to initialize
a CRL for the intermediate CA if the loader does not find one in the
`crl-chain` file. Not having a pre-generated CRL is the typical case as
creating a CRL requires access to the private key of the intermediate
CA. An external CA generally should not have access to this key and is
therefore not able to provide a pre-generated CRL along with the
intermediate CA cert.