### PR TITLE
(SERVER-2727) Allow using Facter 4

### DIFF
--- a/puppetserver-ca.gemspec
+++ b/puppetserver-ca.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "facter", [">= 2.0.1", "< 4"]
+  spec.add_runtime_dependency "facter", [">= 2.0.1", "< 5"]
 
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This commit loosens the version restriction for Facter to allow Facter
4, the new Ruby re-write.