### PR TITLE
(maint) Bump rake dependency to >= 12.3.3

### DIFF
--- a/puppetserver-ca.gemspec
+++ b/puppetserver-ca.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "facter", [">= 2.0.1", "< 5"]
 
   spec.add_development_dependency "bundler", ">= 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This commit bumps the rake dependency in order to address CVE-2020-8130.