### PR TITLE
(SERVER-2896) Update defaults for new cadir

### DIFF
--- a/lib/puppetserver/ca/action/clean.rb
+++ b/lib/puppetserver/ca/action/clean.rb
@@ -85,7 +85,7 @@ BANNER
             return 1 if Errors.handle_with_usage(@logger, errors)
           end
 
-          puppet = Config::Puppet.parse(config)
+          puppet = Config::Puppet.parse(config, @logger)
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 
           result = clean_certs(certnames, puppet.settings)

--- a/lib/puppetserver/ca/action/enable.rb
+++ b/lib/puppetserver/ca/action/enable.rb
@@ -45,7 +45,7 @@ BANNER
           end
 
           puppet = Config::Puppet.new(config_path)
-          puppet.load
+          puppet.load({}, @logger)
           settings = puppet.settings
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 

--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -126,7 +126,7 @@ BANNER
           # Load, resolve, and validate puppet config settings
           settings_overrides = {}
           puppet = Config::Puppet.new(config_path)
-          puppet.load(settings_overrides)
+          puppet.load(settings_overrides, @logger)
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 
           # We don't want generate to respect the alt names setting, since it is usually

--- a/lib/puppetserver/ca/action/import.rb
+++ b/lib/puppetserver/ca/action/import.rb
@@ -55,7 +55,7 @@ BANNER
           settings_overrides[:dns_alt_names] = input['subject-alt-names'] unless input['subject-alt-names'].empty?
 
           puppet = Config::Puppet.new(config_path)
-          puppet.load(settings_overrides)
+          puppet.load(settings_overrides, @logger)
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 
           # Load most secure signing digest we can for cers/crl/csr signing.

--- a/lib/puppetserver/ca/action/list.rb
+++ b/lib/puppetserver/ca/action/list.rb
@@ -68,7 +68,7 @@ Options:
             return 1 if Errors.handle_with_usage(@logger, errors)
           end
 
-          puppet = Config::Puppet.parse(config)
+          puppet = Config::Puppet.parse(config, @logger)
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 
           filter_names = certnames.any? \

--- a/lib/puppetserver/ca/action/migrate.rb
+++ b/lib/puppetserver/ca/action/migrate.rb
@@ -29,7 +29,7 @@ BANNER
         def run(input)
           config_path = input['config']
           puppet = Config::Puppet.new(config_path)
-          puppet.load
+          puppet.load({}, @logger)
           return 1 if HttpClient.check_server_online(puppet.settings, @logger)
 
           errors = FileSystem.check_for_existing_files(PUPPETSERVER_CA_DIR)

--- a/lib/puppetserver/ca/action/revoke.rb
+++ b/lib/puppetserver/ca/action/revoke.rb
@@ -83,7 +83,7 @@ BANNER
             return 1 if Errors.handle_with_usage(@logger, errors)
           end
 
-          puppet = Config::Puppet.parse(config)
+          puppet = Config::Puppet.parse(config, @logger)
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 
           result =  revoke_certs(certnames, puppet.settings)

--- a/lib/puppetserver/ca/action/setup.rb
+++ b/lib/puppetserver/ca/action/setup.rb
@@ -55,7 +55,7 @@ BANNER
           settings_overrides[:dns_alt_names] = input['subject-alt-names'] unless input['subject-alt-names'].empty?
 
           puppet = Config::Puppet.new(config_path)
-          puppet.load(settings_overrides)
+          puppet.load(settings_overrides, @logger)
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 
           # Load most secure signing digest we can for cers/crl/csr signing.

--- a/lib/puppetserver/ca/action/sign.rb
+++ b/lib/puppetserver/ca/action/sign.rb
@@ -62,7 +62,7 @@ Options:
             return 1 if Errors.handle_with_usage(@logger, errors)
           end
 
-          puppet = Config::Puppet.parse(config)
+          puppet = Config::Puppet.parse(config, @logger)
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 
           ca = Puppetserver::Ca::CertificateAuthority.new(@logger, puppet.settings)

--- a/spec/puppetserver/ca/action/clean_spec.rb
+++ b/spec/puppetserver/ca/action/clean_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'utils/http'
+require 'utils/helpers'
 
 require 'puppetserver/ca/action/clean'
 require 'puppetserver/ca/logger'
@@ -73,7 +74,7 @@ RSpec.describe Puppetserver::Ca::Action::Clean do
       expect(code).to eq(0)
       expect(stdout.string).to match(/Revoked.*foo/)
       expect(stdout.string).to include('Cleaned files related to foo')
-      expect(stderr.string).to be_empty
+      expect(Utils::Helpers.remove_cadir_deprecation(stderr)).to be_empty
     end
 
     it 'logs success and returns zero if cleaned but already revoked' do
@@ -83,7 +84,7 @@ RSpec.describe Puppetserver::Ca::Action::Clean do
       code = subject.run({'certnames' => ['foo']})
       expect(code).to eq(0)
       expect(stdout.string).to include('Cleaned files related to foo')
-      expect(stderr.string).to be_empty
+      expect(Utils::Helpers.remove_cadir_deprecation(stderr)).to be_empty
     end
 
     it 'fails and does not attempt to clean if revocation fails' do
@@ -116,7 +117,7 @@ RSpec.describe Puppetserver::Ca::Action::Clean do
       expect(code).to eq(24)
       expect(stdout.string).to include('Cleaned files related to bar')
       expect(stdout.string).to include('Cleaned files related to foo')
-      expect(stderr.string).to be_empty
+      expect(Utils::Helpers.remove_cadir_deprecation(stderr)).to be_empty
     end
 
     it 'logs returns 1 if some were unsigned and not found' do

--- a/spec/puppetserver/ca/action/migrate_spec.rb
+++ b/spec/puppetserver/ca/action/migrate_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Puppetserver::Ca::Action::Migrate do
   describe '#run' do
     let(:filesystem) { Puppetserver::Ca::Utils::FileSystem }
     let(:httpclient) { Puppetserver::Ca::Utils::HttpClient }
-    let(:config) { Puppetserver::Ca::Config::Puppet.new.load }
+    let(:config) { Puppetserver::Ca::Config::Puppet.new.load({}, logger) }
 
     it 'exits with 1 when the server is found running' do
       allow(httpclient).to receive(:check_server_online).and_return(true)

--- a/spec/puppetserver/ca/action/revoke_spec.rb
+++ b/spec/puppetserver/ca/action/revoke_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'utils/http'
+require 'utils/helpers'
 
 require 'puppetserver/ca/action/revoke'
 require 'puppetserver/ca/logger'
@@ -69,7 +70,7 @@ RSpec.describe Puppetserver::Ca::Action::Revoke do
       code = subject.run({'certnames' => ['foo']})
       expect(code).to eq(0)
       expect(stdout.string.chomp).to eq('Revoked certificate for foo')
-      expect(stderr.string).to be_empty
+      expect(Utils::Helpers.remove_cadir_deprecation(stderr)).to be_empty
     end
 
     it 'logs an error and returns 1 if any could not be revoked' do

--- a/spec/puppetserver/ca/local_certificate_authority_spec.rb
+++ b/spec/puppetserver/ca/local_certificate_authority_spec.rb
@@ -1,16 +1,22 @@
 require 'puppetserver/ca/local_certificate_authority'
+
 require 'puppetserver/ca/config/puppet'
+require 'puppetserver/ca/logger'
+require 'puppetserver/ca/utils/signing_digest'
 
 require 'utils/ssl'
-require 'puppetserver/ca/utils/signing_digest'
+require 'stringio'
 
 RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
   include Utils::SSL
 
   let(:tmpdir) { Dir.mktmpdir }
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+  let(:logger) { Puppetserver::Ca::Logger.new(:info, stdout, stderr) }
   let(:settings) {
     with_ca_in(tmpdir) do |config, confdir|
-      return Puppetserver::Ca::Config::Puppet.new(config).load({confdir: confdir })
+      return Puppetserver::Ca::Config::Puppet.new(config).load({confdir: confdir }, logger)
     end
   }
 
@@ -30,7 +36,7 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
     context 'when an ssl asset is missing' do
       let(:settings) {
         with_ca_in(Dir.mktmpdir) do |config|
-          return Puppetserver::Ca::Config::Puppet.new(config).load({cacert: '/some/rando/path'})
+          return Puppetserver::Ca::Config::Puppet.new(config).load({cacert: '/some/rando/path'}, logger)
         end
       }
       it 'does not load ssl assets if they are not found' do

--- a/spec/puppetserver/ca/utils/http_client_spec.rb
+++ b/spec/puppetserver/ca/utils/http_client_spec.rb
@@ -10,46 +10,42 @@ require 'puppetserver/ca/action/setup'
 
 RSpec.describe Puppetserver::Ca::Utils::HttpClient do
   include Utils::SSL
-  let(:tmpdir) {Dir.mktmpdir}
-  let(:settings) {
-    with_ca_in(tmpdir) do |config, confdir|
-      Puppetserver::Ca::Config::Puppet.new(config).load({
-        :hostcert => "#{tmpdir}/hostcert.pem",
-        :hostprivkey => "#{tmpdir}/hostkey.pem",
-        :confdir => confdir
-      })
-    end
-  }
-
-  after do
-    FileUtils.rm_rf(tmpdir)
-  end
 
   it 'creates a store that can validate connections to CA' do
+    tmpdir = Dir.mktmpdir
     stdout = StringIO.new
     stderr = StringIO.new
     logger = Puppetserver::Ca::Logger.new(:info, stdout, stderr)
-    setup_action = Puppetserver::Ca::Action::Setup.new(logger)
 
-    signer = Puppetserver::Ca::Utils::SigningDigest.new
-    setup_action.generate_pki(settings, signer.digest)
+    with_ca_in(tmpdir) do |config, confdir|
+      settings = Puppetserver::Ca::Config::Puppet.new(config).load({
+        :hostcert    => "#{tmpdir}/hostcert.pem",
+        :hostprivkey => "#{tmpdir}/hostkey.pem",
+        :confdir     => confdir
+      }, logger)
 
-    loader = Puppetserver::Ca::X509Loader.new(settings[:cacert], settings[:cakey], settings[:cacrl])
-    cakey = loader.key
-    cacert = loader.cert
+      setup_action = Puppetserver::Ca::Action::Setup.new(logger)
 
-    hostkey = OpenSSL::PKey::RSA.new(512)
-    hostcert = create_cert(hostkey, 'foobar', cakey, cacert)
-    File.write("#{tmpdir}/hostcert.pem", hostcert)
-    File.write("#{tmpdir}/hostkey.pem", hostkey)
+      signer = Puppetserver::Ca::Utils::SigningDigest.new
+      setup_action.generate_pki(settings, signer.digest)
 
-    FileUtils.cp(settings[:cacert], settings[:localcacert])
-    FileUtils.cp(settings[:cacrl], settings[:hostcrl])
+      loader = Puppetserver::Ca::X509Loader.new(settings[:cacert], settings[:cakey], settings[:cacrl])
+      cakey = loader.key
+      cacert = loader.cert
 
-    client = Puppetserver::Ca::Utils::HttpClient.new(settings)
-    store = client.store
+      hostkey = OpenSSL::PKey::RSA.new(512)
+      hostcert = create_cert(hostkey, 'foobar', cakey, cacert)
+      File.write("#{tmpdir}/hostcert.pem", hostcert)
+      File.write("#{tmpdir}/hostkey.pem", hostkey)
 
-    expect(store.verify(hostcert)).to be(true)
-    expect(store.verify(cacert)).to be(true)
+      FileUtils.cp(settings[:cacert], settings[:localcacert])
+      FileUtils.cp(settings[:cacrl], settings[:hostcrl])
+
+      client = Puppetserver::Ca::Utils::HttpClient.new(settings)
+      store = client.store
+
+      expect(store.verify(hostcert)).to be(true)
+      expect(store.verify(cacert)).to be(true)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "bundler/setup"
 Bundler.require(:default)
 
 require "puppetserver/ca"
+require 'tmpdir'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/utils/helpers.rb
+++ b/spec/utils/helpers.rb
@@ -1,0 +1,10 @@
+
+module Utils
+  module Helpers
+    def self.remove_cadir_deprecation(io)
+      io.string.each_line.reject do |line|
+        line =~ /migrate out from the puppet confdir to the \/etc\/puppetlabs\/puppetserver\/ca/
+      end
+    end
+  end
+end


### PR DESCRIPTION
With Puppet 7 the cadir location will move by default from `$ssldir` to
Puppet Server's confdir. However we want to respect any users that have
already created their cadir in either the old default location or a new
location. We also want to warn if they have it in the old location that
they should migrate the cadir. If users have a custom cadir but it
resides in the ssldir we also want to warn, a cadir within the ssldir
may cause accidental deletion of the cadir.