### PR TITLE
(SERVER-2895) Symlink to old cadir when setting up with the new default

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,26 @@ interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 
-To release a new version, update the version number in `version.rb`, and then
-speak with Release Engineering.
+### Testing
+To test your changes on a VM:
+1. Build the gem with your changes: `gem build puppetserver-ca.gemspec`
+1. Copy the gem to your VM: `scp puppetserver-ca-<version>.gem <your-vm>:.`
+1. Install puppetserver (FOSS) by installing the relevant release package and then installing the puppetserver package. For example:
+    ```
+    $ wget http://nightlies.puppet.com/yum/puppet6-nightly-release-el-7.noarch.rpm
+    $ rpm -i puppet6-nightly-release-el-7.noarch.rpm
+    $ yum update
+    $ yum install -y puppetserver
+    ```
+1. Restart your shell so that puppet's bin dir is on your $PATH: `exec bash`
+1. Install the gem into puppet's gem directory using puppet's gem command:
+    ```
+    $ /opt/puppetlabs/puppet/bin/gem install --install-dir "/opt/puppetlabs/puppet/lib/ruby/vendor_gems" puppetserver-ca-<version>.gem
+    ```
+1. To confirm that installation was successful, run `puppetserver ca --help`
+
+### Releasing
+To release a new version, run the [release pipeline](https://jenkins-master-prod-1.delivery.puppetlabs.net/job/platform_puppetserver-ca_init-multijob_main/), which will bump the version, tag, build, and release the gem.
 
 
 ## Contributing & Support

--- a/lib/puppetserver/ca/action/import.rb
+++ b/lib/puppetserver/ca/action/import.rb
@@ -4,6 +4,7 @@ require 'puppetserver/ca/config/puppet'
 require 'puppetserver/ca/errors'
 require 'puppetserver/ca/local_certificate_authority'
 require 'puppetserver/ca/utils/cli_parsing'
+require 'puppetserver/ca/utils/config'
 require 'puppetserver/ca/utils/file_system'
 require 'puppetserver/ca/utils/signing_digest'
 require 'puppetserver/ca/x509_loader'
@@ -129,6 +130,8 @@ ERR
           private_files.each do |location, content|
             FileSystem.write_file(location, content, 0640)
           end
+
+          Puppetserver::Ca::Utils::Config.symlink_to_old_cadir(settings[:cadir], settings[:confdir])
 
           return []
         end

--- a/lib/puppetserver/ca/action/setup.rb
+++ b/lib/puppetserver/ca/action/setup.rb
@@ -3,6 +3,7 @@ require 'optparse'
 require 'puppetserver/ca/config/puppet'
 require 'puppetserver/ca/errors'
 require 'puppetserver/ca/local_certificate_authority'
+require 'puppetserver/ca/utils/config'
 require 'puppetserver/ca/utils/cli_parsing'
 require 'puppetserver/ca/utils/file_system'
 require 'puppetserver/ca/utils/signing_digest'
@@ -134,6 +135,8 @@ ERR
           private_files.each do |location, content|
             FileSystem.write_file(location, content, 0640)
           end
+
+          Puppetserver::Ca::Utils::Config.symlink_to_old_cadir(settings[:cadir], settings[:confdir])
 
           return []
         end

--- a/lib/puppetserver/ca/config/puppet.rb
+++ b/lib/puppetserver/ca/config/puppet.rb
@@ -40,10 +40,6 @@ module Puppetserver
           @errors = []
         end
 
-        def running_as_root?
-          @as_root ||= Puppetserver::Ca::Utils::Config.running_as_root?
-        end
-
         # Return the correct confdir. We check for being root on *nix,
         # else the user path. We do not include a check for running
         # as Adminstrator since non-development scenarios for Puppet Server
@@ -51,12 +47,7 @@ module Puppetserver
         # Note that Puppet Server runs as the [pe-]puppet user but to
         # start/stop it you must be root.
         def user_specific_puppet_confdir
-          @user_specific_puppet_confdir ||=
-            if running_as_root?
-              '/etc/puppetlabs/puppet'
-            else
-              "#{ENV['HOME']}/.puppetlabs/etc/puppet"
-            end
+          @user_specific_puppet_confdir ||= Puppetserver::Ca::Utils::Config.puppet_confdir
         end
 
         def user_specific_puppet_config
@@ -65,12 +56,7 @@ module Puppetserver
 
         # The same comments regarding the Puppet confdir apply here.
         def user_specific_puppetserver_confdir
-          @user_specific_puppetserver_confdir ||=
-            if running_as_root?
-              '/etc/puppetlabs/puppetserver'
-            else
-              "#{ENV['HOME']}/.puppetlabs/etc/puppetserver"
-            end
+          @user_specific_puppetserver_confdir ||= Puppetserver::Ca::Utils::Config.puppetserver_confdir
         end
 
         def load(cli_overrides = {}, logger)
@@ -246,8 +232,8 @@ module Puppetserver
             configured_cadir
 
           else
-            old_cadir = File.join(ssldir, 'ca')
-            new_cadir = File.join(File.dirname(confdir), 'puppetserver', 'ca')
+            old_cadir = Puppetserver::Ca::Utils::Config.old_default_cadir(confdir)
+            new_cadir = Puppetserver::Ca::Utils::Config.new_default_cadir(confdir)
             if File.exist?(old_cadir) && !File.symlink?(old_cadir)
               logger.warn(warning % {ssldir: ssldir})
               old_cadir

--- a/lib/puppetserver/ca/config/puppet.rb
+++ b/lib/puppetserver/ca/config/puppet.rb
@@ -54,11 +54,6 @@ module Puppetserver
           user_specific_puppet_confdir + '/puppet.conf'
         end
 
-        # The same comments regarding the Puppet confdir apply here.
-        def user_specific_puppetserver_confdir
-          @user_specific_puppetserver_confdir ||= Puppetserver::Ca::Utils::Config.puppetserver_confdir
-        end
-
         def load(cli_overrides = {}, logger)
           if explicitly_given_config_file_or_default_config_exists?
             results = parse_text(File.read(@config_path))

--- a/lib/puppetserver/ca/utils/config.rb
+++ b/lib/puppetserver/ca/utils/config.rb
@@ -1,3 +1,5 @@
+require 'puppetserver/ca/utils/file_system'
+
 module Puppetserver
   module Ca
     module Utils
@@ -17,6 +19,40 @@ module Puppetserver
               name
             end
           end.sort.uniq.join(", ")
+        end
+
+        def self.puppet_confdir
+          if running_as_root?
+            '/etc/puppetlabs/puppet'
+          else
+            "#{ENV['HOME']}/.puppetlabs/etc/puppet"
+          end
+        end
+
+        def self.puppetserver_confdir(puppet_confdir)
+          File.join(File.dirname(puppet_confdir), 'puppetserver')
+        end
+
+        def self.default_ssldir(confdir = puppet_confdir)
+          File.join(confdir, 'ssl')
+        end
+
+        def self.old_default_cadir(confdir = puppet_confdir)
+          File.join(confdir, 'ssl', 'ca')
+        end
+
+        def self.new_default_cadir(confdir = puppet_confdir)
+          File.join(puppetserver_confdir(confdir), 'ca')
+        end
+
+        def self.symlink_to_old_cadir(current_cadir, puppet_confdir)
+          old_cadir = old_default_cadir(puppet_confdir)
+          new_cadir = new_default_cadir(puppet_confdir)
+          return if current_cadir != new_cadir
+          # This is only run on setup/import, so there should be no files in the
+          # old cadir, so it should be safe to forcibly remove it (which we need
+          # to do in order to create a symlink).
+          Puppetserver::Ca::Utils::FileSystem.forcibly_symlink(new_cadir, old_cadir)
         end
 
       end

--- a/lib/puppetserver/ca/utils/file_system.rb
+++ b/lib/puppetserver/ca/utils/file_system.rb
@@ -50,6 +50,11 @@ module Puppetserver
           errors
         end
 
+        def self.forcibly_symlink(source, link_target)
+          FileUtils.remove_dir(link_target, true)
+          FileUtils.symlink(source, link_target)
+        end
+
         def initialize
           @user, @group = find_user_and_group
         end

--- a/puppetserver-ca.gemspec
+++ b/puppetserver-ca.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "facter", [">= 2.0.1", "< 5"]
 
   spec.add_development_dependency "bundler", ">= 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/spec/puppetserver/ca/config/puppet_spec.rb
+++ b/spec/puppetserver/ca/config/puppet_spec.rb
@@ -264,6 +264,7 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
       File.open puppet_conf, 'w' do |f|
         f.puts(<<-INI)
           [main]
+            confdir = #{tmpdir}
             ssldir = #{ssldir}
         INI
       end


### PR DESCRIPTION
This commit adds a method to symlink the new default cadir to the old default
cadir location when running the `setup` and `import` commands. This ensures
that, even on new installs, we can access the cadir from the old location
because there are still tools in the ecosystem that expect the old location.