### PR TITLE
(SERVER-2931) Do not warn about old CA dir location when migrating

### DIFF
--- a/lib/puppetserver/ca/action/enable.rb
+++ b/lib/puppetserver/ca/action/enable.rb
@@ -45,7 +45,7 @@ BANNER
           end
 
           puppet = Config::Puppet.new(config_path)
-          puppet.load({}, @logger)
+          puppet.load(logger: @logger)
           settings = puppet.settings
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 

--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -126,7 +126,7 @@ BANNER
           # Load, resolve, and validate puppet config settings
           settings_overrides = {}
           puppet = Config::Puppet.new(config_path)
-          puppet.load(settings_overrides, @logger)
+          puppet.load(cli_overrides: settings_overrides, logger: @logger)
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 
           # We don't want generate to respect the alt names setting, since it is usually

--- a/lib/puppetserver/ca/action/import.rb
+++ b/lib/puppetserver/ca/action/import.rb
@@ -56,7 +56,7 @@ BANNER
           settings_overrides[:dns_alt_names] = input['subject-alt-names'] unless input['subject-alt-names'].empty?
 
           puppet = Config::Puppet.new(config_path)
-          puppet.load(settings_overrides, @logger)
+          puppet.load(cli_overrides: settings_overrides, logger: @logger)
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 
           # Load most secure signing digest we can for cers/crl/csr signing.

--- a/lib/puppetserver/ca/action/migrate.rb
+++ b/lib/puppetserver/ca/action/migrate.rb
@@ -29,7 +29,7 @@ BANNER
         def run(input)
           config_path = input['config']
           puppet = Config::Puppet.new(config_path)
-          puppet.load({}, @logger)
+          puppet.load(logger: @logger, ca_dir_warn: false)
           return 1 if HttpClient.check_server_online(puppet.settings, @logger)
 
           errors = FileSystem.check_for_existing_files(PUPPETSERVER_CA_DIR)

--- a/lib/puppetserver/ca/action/migrate.rb
+++ b/lib/puppetserver/ca/action/migrate.rb
@@ -1,22 +1,23 @@
 require 'puppetserver/ca/utils/cli_parsing'
 require 'puppetserver/ca/utils/file_system'
 require 'puppetserver/ca/utils/http_client'
+require 'puppetserver/ca/utils/config'
 
 module Puppetserver
   module Ca
     module Action
       class Migrate
         include Puppetserver::Ca::Utils
-        PUPPETSERVER_CA_DIR = '/etc/puppetlabs/puppetserver/ca'
+        PUPPETSERVER_CA_DIR = Puppetserver::Ca::Utils::Config.new_default_cadir
 
-        SUMMARY = "Migrate the existing CA directory to /etc/puppetlabs/puppetserver/ca"
+        SUMMARY = "Migrate the existing CA directory to #{PUPPETSERVER_CA_DIR}"
         BANNER = <<-BANNER
 Usage:
   puppetserver ca migrate [--help]
   puppetserver ca migrate [--config PATH]
 
 Description:
-  Migrate an existing CA directory to /etc/puppetlabs/puppetserver/ca. This is for
+  Migrate an existing CA directory to #{PUPPETSERVER_CA_DIR}. This is for
   upgrading from Puppet Platform 6.x to Puppet 7. Use the currently configured
   puppet.conf file in your installation, or supply one using the `--config` flag.
 Options:

--- a/lib/puppetserver/ca/action/setup.rb
+++ b/lib/puppetserver/ca/action/setup.rb
@@ -56,7 +56,7 @@ BANNER
           settings_overrides[:dns_alt_names] = input['subject-alt-names'] unless input['subject-alt-names'].empty?
 
           puppet = Config::Puppet.new(config_path)
-          puppet.load(settings_overrides, @logger)
+          puppet.load(cli_overrides: settings_overrides, logger: @logger)
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 
           # Load most secure signing digest we can for cers/crl/csr signing.

--- a/spec/puppetserver/ca/action/migrate_spec.rb
+++ b/spec/puppetserver/ca/action/migrate_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Puppetserver::Ca::Action::Migrate do
   describe '#run' do
     let(:filesystem) { Puppetserver::Ca::Utils::FileSystem }
     let(:httpclient) { Puppetserver::Ca::Utils::HttpClient }
-    let(:config) { Puppetserver::Ca::Config::Puppet.new.load({}, logger) }
+    let(:config) { Puppetserver::Ca::Config::Puppet.new.load(logger: logger) }
 
     it 'exits with 1 when the server is found running' do
       allow(httpclient).to receive(:check_server_online).and_return(true)

--- a/spec/puppetserver/ca/config/puppet_spec.rb
+++ b/spec/puppetserver/ca/config/puppet_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
       end
 
       conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
-      conf.load({}, logger)
+      conf.load(logger: logger)
 
       expect(conf.errors).to be_empty
       expect(conf.settings[:localcacert]).to eq('/foo/bar/certs/ca.pem')
@@ -141,7 +141,7 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
       end
 
       conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
-      conf.load({}, logger)
+      conf.load(logger: logger)
 
       expect(conf.errors).to be_empty
       expect(conf.settings[:certname]).to eq('master-certname')
@@ -161,7 +161,7 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
       end
 
       conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
-      conf.load({}, logger)
+      conf.load(logger: logger)
 
       expect(conf.errors).to be_empty
       expect(conf.settings[:ca_ttl]).to eq(157680000)
@@ -183,7 +183,7 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
         end
 
         conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
-        conf.load({}, logger)
+        conf.load(logger: logger)
 
         expect(conf.errors).to be_empty
         expect(conf.settings[:subject_alt_names]).
@@ -204,7 +204,7 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
         end
 
         conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
-        conf.load({}, logger)
+        conf.load(logger: logger)
 
         expect(conf.errors).to be_empty
         expect(conf.settings[:subject_alt_names]).
@@ -224,7 +224,7 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
       end
 
       conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
-      conf.load({}, logger)
+      conf.load(logger: logger)
 
       expect(conf.errors.first).to include('$vardir in $vardir/ssl')
       expect(conf.settings[:localcacert]).to eq('$vardir/ssl/certs/ca.pem')
@@ -247,7 +247,7 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
       end
 
       conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
-      settings = conf.load({}, logger)
+      settings = conf.load(logger: logger)
 
       expect(settings[:cadir]).to eq(cadir)
       expect(stderr.string.each_line.first).
@@ -270,7 +270,7 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
       end
 
       conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
-      settings = conf.load({}, logger)
+      settings = conf.load(logger: logger)
 
       expect(settings[:cadir]).to eq(cadir)
       expect(stderr.string.each_line.first).
@@ -294,7 +294,7 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
       end
 
       conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
-      settings = conf.load({}, logger)
+      settings = conf.load(logger: logger)
 
       expect(settings[:cadir]).to eq(cadir)
       expect(stderr.string).to be_empty
@@ -313,7 +313,7 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
       end
 
       conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
-      settings = conf.load({}, logger)
+      settings = conf.load(logger: logger)
 
       expect(settings[:ssldir]).to eq(File.join(confdir, 'ssl'))
       expect(settings[:cadir]).to eq(File.join(tmpdir, 'puppetserver', 'ca'))

--- a/spec/puppetserver/ca/local_certificate_authority_spec.rb
+++ b/spec/puppetserver/ca/local_certificate_authority_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
   let(:logger) { Puppetserver::Ca::Logger.new(:info, stdout, stderr) }
   let(:settings) {
     with_ca_in(tmpdir) do |config, confdir|
-      return Puppetserver::Ca::Config::Puppet.new(config).load({confdir: confdir }, logger)
+      return Puppetserver::Ca::Config::Puppet.new(config).load(cli_overrides: {confdir: confdir }, logger: logger)
     end
   }
 
@@ -36,7 +36,7 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
     context 'when an ssl asset is missing' do
       let(:settings) {
         with_ca_in(Dir.mktmpdir) do |config|
-          return Puppetserver::Ca::Config::Puppet.new(config).load({cacert: '/some/rando/path'}, logger)
+          return Puppetserver::Ca::Config::Puppet.new(config).load(cli_overrides: {cacert: '/some/rando/path'}, logger: logger)
         end
       }
       it 'does not load ssl assets if they are not found' do

--- a/spec/puppetserver/ca/utils/http_client_spec.rb
+++ b/spec/puppetserver/ca/utils/http_client_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe Puppetserver::Ca::Utils::HttpClient do
     logger = Puppetserver::Ca::Logger.new(:info, stdout, stderr)
 
     with_ca_in(tmpdir) do |config, confdir|
-      settings = Puppetserver::Ca::Config::Puppet.new(config).load({
+      settings = Puppetserver::Ca::Config::Puppet.new(config).load(cli_overrides: {
         :hostcert    => "#{tmpdir}/hostcert.pem",
         :hostprivkey => "#{tmpdir}/hostkey.pem",
         :confdir     => confdir
-      }, logger)
+      }, logger: logger)
 
       setup_action = Puppetserver::Ca::Action::Setup.new(logger)
 


### PR DESCRIPTION
This commit adds an internal flag to disable the warning about using the
old CA dir location, so that it can be disabled when running the
`migrate` command.