### PR TITLE
(SERVER-2338) Ensure `ca-client` cert has certname as altname

### DIFF
--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -296,7 +296,9 @@ BANNER
         end
 
         def process_alt_names(alt_names, certname)
-          return '' if alt_names.empty?
+          # It is recommended (and sometimes enforced) to always include
+          # the certname as a SAN, see RFC 2818 https://tools.ietf.org/html/rfc2818#section-3.1.
+          return "DNS:#{certname}" if alt_names.empty?
 
           current_alt_names = alt_names.dup
           # When validating the cert, OpenSSL will ignore the CN field if


### PR DESCRIPTION
We previously updated the certificate signing code in puppetserver
proper to always add the certname as a subject alt name when signing a
certificate. This commit updates the `generate` action of the CLI gem to
also ensure that the certname of the host the cert is being generated
for is added as an alt name. Because `generate` is used to create certs
for other hosts, we can't use the value of `certname` from settings in
the CA code itself, but rather need to use the value of `certname` that
is passed into the command.