### PR TITLE
(maint) Fix bad memoization in default certname

### DIFF
--- a/lib/puppetserver/ca/config/puppet.rb
+++ b/lib/puppetserver/ca/config/puppet.rb
@@ -79,15 +79,14 @@ module Puppetserver
         end
 
         def default_certname
-          @certname ||=
-            hostname = Facter.value(:hostname)
-            domain = Facter.value(:domain)
-            if domain and domain != ''
-              fqdn = [hostname, domain].join('.')
-            else
-              fqdn = hostname
-            end
-            fqdn.chomp('.')
+          hostname = Facter.value(:hostname)
+          domain = Facter.value(:domain)
+          if domain and domain != ''
+            fqdn = [hostname, domain].join('.')
+          else
+            fqdn = hostname
+          end
+          fqdn.chomp('.')
         end
 
         # Resolve settings from default values, with any overrides for the

--- a/spec/puppetserver/ca/config/puppet_spec.rb
+++ b/spec/puppetserver/ca/config/puppet_spec.rb
@@ -223,4 +223,22 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
       expect(conf.settings[:cacert]).to eq('$vardir/ssl/ca/ca_crt.pem')
     end
   end
+
+  context 'building the default certname' do
+    it 'when there is a domain, concatenates the hostname and domain' do
+      expect(Facter).to receive(:value).with(:hostname).and_return("foo")
+      expect(Facter).to receive(:value).with(:domain).and_return("example.com")
+
+      conf = Puppetserver::Ca::Config::Puppet.new
+      expect(conf.default_certname).to eq("foo.example.com")
+    end
+
+    it 'when domain is nil, returns just the hostname' do
+      expect(Facter).to receive(:value).with(:hostname).and_return("foo")
+      expect(Facter).to receive(:value).with(:domain).and_return(nil)
+
+      conf = Puppetserver::Ca::Config::Puppet.new
+      expect(conf.default_certname).to eq("foo")
+    end
+  end
 end


### PR DESCRIPTION
The `default_certname` method would do the right thing the first time it
was called, and then afterwards fail to get the hostname. This commit
fixes the bad short circuiting logic.