### PR TITLE
(SERVER-2993) Detect migrated CA dir when calcuating settings

### DIFF
--- a/lib/puppetserver/ca/utils/config.rb
+++ b/lib/puppetserver/ca/utils/config.rb
@@ -19,6 +19,25 @@ module Puppetserver
           end.sort.uniq.join(", ")
         end
 
+        def self.puppet_confdir
+          if running_as_root?
+            '/etc/puppetlabs/puppet'
+          else
+            "#{ENV['HOME']}/.puppetlabs/etc/puppet"
+          end
+        end
+
+        def self.puppetserver_confdir(puppet_confdir)
+          File.join(File.dirname(puppet_confdir), 'puppetserver')
+        end
+
+        def self.old_default_cadir(confdir = puppet_confdir)
+          File.join(confdir, 'ssl', 'ca')
+        end
+
+        def self.new_default_cadir(confdir = puppet_confdir)
+          File.join(puppetserver_confdir(confdir), 'ca')
+        end
       end
     end
   end


### PR DESCRIPTION
This commit updates the settings resolution logic to detect when the CA
dir has been migrated, to return the new location in that case. If the
new dir does not have CA content, the old location is returned
(including if no dir exists).