### PR TITLE
(SERVER-2932) Update terminology in ca cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ puppetserver ca --help
 ```
 
 This code in this project is licensed under the Apache Software License v2,
-please see the included [License](https://github.com/puppetlabs/puppetserver-ca-cli/blob/master/LICENSE.md)
+please see the included [License](https://github.com/puppetlabs/puppetserver-ca-cli/blob/main/LICENSE.md)
 for more details.
 
 
@@ -105,9 +105,9 @@ Freenode, or the Puppet Community Slack channel.
 
 Contributions are welcome at https://github.com/puppetlabs/puppetserver-ca-cli/pulls.
 Contributors should both be sure to read the
-[contributing document](https://github.com/puppetlabs/puppetserver-ca-cli/blob/master/CONTRIBUTING.md)
+[contributing document](https://github.com/puppetlabs/puppetserver-ca-cli/blob/main/CONTRIBUTING.md)
 and sign the [contributor license agreement](https://cla.puppet.com/).
 
 Everyone interacting with the project’s codebase, issue tracker, etc is expected
 to follow the
-[code of conduct](https://github.com/puppetlabs/puppetserver-ca-cli/blob/master/CODE_OF_CONDUCT.md).
+[code of conduct](https://github.com/puppetlabs/puppetserver-ca-cli/blob/main/CODE_OF_CONDUCT.md).

--- a/lib/puppetserver/ca/action/clean.rb
+++ b/lib/puppetserver/ca/action/clean.rb
@@ -14,7 +14,7 @@ module Puppetserver
 
         include Puppetserver::Ca::Utils
 
-        CERTNAME_BLACKLIST = %w{--all --config}
+        CERTNAME_BLOCKLIST = %w{--all --config}
 
         SUMMARY = 'Revoke cert(s) and remove related files from CA'
         BANNER = <<-BANNER
@@ -59,7 +59,7 @@ BANNER
           errors = CliParsing.parse_with_errors(parser, args)
 
           results['certnames'].each do |certname|
-            if CERTNAME_BLACKLIST.include?(certname)
+            if CERTNAME_BLOCKLIST.include?(certname)
               errors << "    Cannot manage cert named `#{certname}` from " +
                         "the CLI, if needed use the HTTP API directly"
             end

--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -35,7 +35,7 @@ Description:
   If the `--ca-client` flag is passed, the cert will be generated
   offline, without using Puppet Server's signing code, and will add
   a special extension authorizing it to talk to the CA API. This can
-  be used for regenerating the master's host cert, or for manually
+  be used for regenerating the server's host cert, or for manually
   setting up other nodes to be CA clients. Do not distribute certs
   generated this way to any node that you do not intend to have
   administrative access to the CA (e.g. the ability to sign a cert).

--- a/lib/puppetserver/ca/action/generate.rb
+++ b/lib/puppetserver/ca/action/generate.rb
@@ -18,7 +18,7 @@ module Puppetserver
 
         # Only allow printing ascii characters, excluding /
         VALID_CERTNAME = /\A[ -.0-~]+\Z/
-        CERTNAME_BLACKLIST = %w{--all --config}
+        CERTNAME_BLOCKLIST = %w{--all --config}
 
         SUMMARY = "Generate a new certificate signed by the CA"
         BANNER = <<-BANNER
@@ -91,7 +91,7 @@ BANNER
             errors << '    At least one certname is required to generate'
           else
             results['certnames'].each do |certname|
-              if CERTNAME_BLACKLIST.include?(certname)
+              if CERTNAME_BLOCKLIST.include?(certname)
                 errors << "    Cannot manage cert named `#{certname}` from " +
                           "the CLI, if needed use the HTTP API directly"
               end

--- a/lib/puppetserver/ca/action/revoke.rb
+++ b/lib/puppetserver/ca/action/revoke.rb
@@ -12,7 +12,7 @@ module Puppetserver
 
         include Puppetserver::Ca::Utils
 
-        CERTNAME_BLACKLIST = %w{--all --config}
+        CERTNAME_BLOCKLIST = %w{--all --config}
 
         SUMMARY = 'Revoke certificate(s)'
         BANNER = <<-BANNER
@@ -55,7 +55,7 @@ BANNER
           errors = CliParsing.parse_with_errors(parser, args)
 
           results['certnames'].each do |certname|
-            if CERTNAME_BLACKLIST.include?(certname)
+            if CERTNAME_BLOCKLIST.include?(certname)
               errors << "    Cannot manage cert named `#{certname}` from " +
                         "the CLI, if needed use the HTTP API directly"
             end

--- a/lib/puppetserver/ca/action/setup.rb
+++ b/lib/puppetserver/ca/action/setup.rb
@@ -23,10 +23,10 @@ Usage:
 Description:
   Setup a root and intermediate signing CA for Puppet Server
   and store generated CA keys, certs, crls, and associated
-  master related files on disk.
+  server related files on disk.
 
   The `--subject-alt-names` flag can be used to add SANs to the
-  certificate generated for the Puppet master. Multiple names can be
+  certificate generated for the Puppet server. Multiple names can be
   listed as a comma separated string. These can be either DNS names or
   IP addresses, differentiated by prefixes: `DNS:foo.bar.com,IP:123.456.789`.
   Names with no prefix will be treated as DNS names.
@@ -76,7 +76,7 @@ BANNER
 
           root_key, root_cert, root_crl = ca.create_root_cert
           ca.create_intermediate_cert(root_key, root_cert)
-          master_key, master_cert = ca.create_master_cert
+          server_key, server_cert = ca.create_server_cert
           return ca.errors if ca.errors.any?
 
           FileSystem.ensure_dirs([settings[:ssldir],
@@ -90,28 +90,28 @@ BANNER
             [settings[:cacert], [ca.cert, root_cert]],
             [settings[:cacrl], [ca.crl, root_crl]],
             [settings[:cadir] + '/infra_crl.pem', [ca.crl, root_crl]],
-            [settings[:hostcert], master_cert],
+            [settings[:hostcert], server_cert],
             [settings[:localcacert], [ca.cert, root_cert]],
             [settings[:hostcrl], [ca.crl, root_crl]],
-            [settings[:hostpubkey], master_key.public_key],
+            [settings[:hostpubkey], server_key.public_key],
             [settings[:capub], ca.key.public_key],
-            [settings[:cert_inventory], ca.inventory_entry(master_cert)],
+            [settings[:cert_inventory], ca.inventory_entry(server_cert)],
             [settings[:cadir] + '/infra_inventory.txt', ''],
             [settings[:cadir] + '/infra_serials', ''],
             [settings[:serial], "002"],
-            [File.join(settings[:signeddir], "#{settings[:certname]}.pem"), master_cert],
+            [File.join(settings[:signeddir], "#{settings[:certname]}.pem"), server_cert],
           ]
 
           private_files = [
-            [settings[:hostprivkey], master_key],
+            [settings[:hostprivkey], server_key],
             [settings[:rootkey], root_key],
             [settings[:cakey], ca.key],
           ]
 
           files_to_check = public_files + private_files
-          # We don't want to error if master's keys exist. Certain workflows
+          # We don't want to error if server's keys exist. Certain workflows
           # allow the agent to have already be installed with keys and then
-          # upgraded to be a master. The host class will honor keys, if both
+          # upgraded to be a server. The host class will honor keys, if both
           # public and private exist, and error if only one exists - as is
           # previous behavior.
           files_to_check = files_to_check.map(&:first) - [settings[:hostpubkey], settings[:hostprivkey]]
@@ -160,7 +160,7 @@ ERR
               parsed['config'] = conf
             end
             opts.on('--subject-alt-names NAME[,NAME]',
-                    'Subject alternative names for the master cert') do |sans|
+                    'Subject alternative names for the server cert') do |sans|
               parsed['subject-alt-names'] = sans
             end
             opts.on('--ca-name NAME',
@@ -168,7 +168,7 @@ ERR
               parsed['ca-name'] = name
             end
             opts.on('--certname NAME',
-                    'Common name to use for the master cert') do |name|
+                    'Common name to use for the server cert') do |name|
               parsed['certname'] = name
             end
           end

--- a/lib/puppetserver/ca/config/puppet.rb
+++ b/lib/puppetserver/ca/config/puppet.rb
@@ -74,6 +74,9 @@ module Puppetserver
 
           overrides = results[:agent].merge(results[:main]).merge(results[:master]).merge(results[:server])
           overrides.merge!(cli_overrides)
+          if overrides[:masterport]
+            overrides[:serverport] ||= overrides.delete(:masterport)
+          end
 
           @settings = resolve_settings(overrides).freeze
         end
@@ -108,7 +111,7 @@ module Puppetserver
             [:certdir, '$ssldir/certs'],
             [:certname, default_certname],
             [:server, 'puppet'],
-            [:masterport, '8140'],
+            [:serverport, '8140'],
             [:privatekeydir, '$ssldir/private_keys'],
             [:publickeydir, '$ssldir/public_keys'],
           ]
@@ -126,7 +129,7 @@ module Puppetserver
             :serial => '$cadir/serial',
             :cert_inventory => '$cadir/inventory.txt',
             :ca_server => '$server',
-            :ca_port => '$masterport',
+            :ca_port => '$serverport',
             :localcacert => '$certdir/ca.pem',
             :hostcrl => '$ssldir/crl.pem',
             :hostcert => '$certdir/$certname.pem',
@@ -276,7 +279,7 @@ module Puppetserver
           end
 
           if settings.dig(:server_list, 0, 1) &&
-              settings[:ca_port] == '$masterport'
+              settings[:ca_port] == '$serverport'
 
             settings[:ca_port] = settings.dig(:server_list, 0, 1)
           end

--- a/lib/puppetserver/ca/host.rb
+++ b/lib/puppetserver/ca/host.rb
@@ -58,10 +58,10 @@ module Puppetserver
         @errors = []
       end
 
-      # If both the private and public keys exist for a master then we want
+      # If both the private and public keys exist for a server then we want
       # to honor them here, if only one key exists we want to surface an error,
       # and if neither exist we generate a new key. This logic is necessary for
-      # proper bootstrapping for certain master workflows.
+      # proper bootstrapping for certain server workflows.
       def create_private_key(keylength, private_path = '', public_path = '')
         if File.exists?(private_path) && File.exists?(public_path)
           return OpenSSL::PKey.read(File.read(private_path))

--- a/lib/puppetserver/ca/local_certificate_authority.rb
+++ b/lib/puppetserver/ca/local_certificate_authority.rb
@@ -20,7 +20,7 @@ module Puppetserver
 
       CLI_AUTH_EXT_OID = "1.3.6.1.4.1.34380.1.3.39"
 
-      MASTER_EXTENSIONS = [
+      SERVER_EXTENSIONS = [
         ["basicConstraints", "CA:FALSE", true],
         ["nsComment", "Puppet Server Internal Certificate", false],
         ["authorityKeyIdentifier", "keyid:always", false],
@@ -132,23 +132,23 @@ module Puppetserver
         time.strftime('%Y-%m-%dT%H:%M:%S%Z')
       end
 
-      def create_master_cert
-        master_cert = nil
-        master_key = @host.create_private_key(@settings[:keylength],
+      def create_server_cert
+        server_cert = nil
+        server_key = @host.create_private_key(@settings[:keylength],
                                               @settings[:hostprivkey],
                                               @settings[:hostpubkey])
-        if master_key
-          master_csr = @host.create_csr(name: @settings[:certname], key: master_key)
+        if server_key
+          server_csr = @host.create_csr(name: @settings[:certname], key: server_key)
           if @settings[:subject_alt_names].empty?
             alt_names = "DNS:puppet, DNS:#{@settings[:certname]}"
           else
             alt_names = @settings[:subject_alt_names]
           end
 
-          master_cert = sign_authorized_cert(master_csr, alt_names)
+          server_cert = sign_authorized_cert(server_csr, alt_names)
         end
 
-        return master_key, master_cert
+        return server_key, server_cert
       end
 
       def sign_authorized_cert(csr, alt_names = '')
@@ -176,7 +176,7 @@ module Puppetserver
       end
 
       def add_authorized_extensions(cert, ef)
-        MASTER_EXTENSIONS.each do |ext|
+        SERVER_EXTENSIONS.each do |ext|
           extension = ef.create_extension(*ext)
           cert.add_extension(extension)
         end

--- a/lib/puppetserver/ca/utils/http_client.rb
+++ b/lib/puppetserver/ca/utils/http_client.rb
@@ -166,7 +166,7 @@ module Puppetserver
         def self.check_server_online(settings, logger)
           status_url = URL.new('https', settings[:ca_server], settings[:ca_port], 'status', 'v1', 'simple', 'ca')
           begin
-            # Generating certs offline is necessary if the master cert has been destroyed
+            # Generating certs offline is necessary if the server cert has been destroyed
             # or compromised. Since querying the status endpoint does not require a client cert, and
             # we commonly won't have one, don't require one for creating the connection.
             # Additionally, we want to ensure the server is stopped before migrating the CA dir to

--- a/spec/puppetserver/ca/config/puppet_spec.rb
+++ b/spec/puppetserver/ca/config/puppet_spec.rb
@@ -313,4 +313,39 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
       end
     end
   end
+
+  it 'loads masterport correctly' do
+    masterport = 1234
+    Dir.mktmpdir do |tmpdir|
+      puppet_conf = File.join(tmpdir, 'puppet.conf')
+      File.open puppet_conf, 'w' do |f|
+        f.puts(<<-INI)
+          [server]
+            masterport = #{masterport}
+        INI
+      end
+
+      conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
+      settings = conf.load
+
+      expect(settings[:ca_port]).to eq("#{masterport}")
+    end
+  end
+  it 'loads serverport correctly' do
+    serverport = 1234
+    Dir.mktmpdir do |tmpdir|
+      puppet_conf = File.join(tmpdir, 'puppet.conf')
+      File.open puppet_conf, 'w' do |f|
+        f.puts(<<-INI)
+          [server]
+            serverport = #{serverport}
+        INI
+      end
+
+      conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
+      settings = conf.load
+
+      expect(settings[:ca_port]).to eq("#{serverport}")
+    end
+  end
 end

--- a/spec/puppetserver/ca/local_certificate_authority_spec.rb
+++ b/spec/puppetserver/ca/local_certificate_authority_spec.rb
@@ -50,13 +50,13 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
     end
   end
 
-  describe "#create_master_cert" do
+  describe "#create_server_cert" do
     context "without a csr_attributes file" do
       it "adds only MA extensions to the csr" do
         root_key, root_cert, root_crl = subject.create_root_cert
         subject.create_intermediate_cert(root_key, root_cert)
 
-        _, cert = subject.create_master_cert
+        _, cert = subject.create_server_cert
         expect(cert.extensions.count).to eq(8)
       end
     end
@@ -81,7 +81,7 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
         root_key, root_cert, root_crl = subject.create_root_cert
         subject.create_intermediate_cert(root_key, root_cert)
 
-        _, cert = subject.create_master_cert
+        _, cert = subject.create_server_cert
         expect(cert.extensions.count).to eq(10)
       end
     end

--- a/spec/shared_examples/setup.rb
+++ b/spec/shared_examples/setup.rb
@@ -83,7 +83,7 @@ RSpec.shared_examples 'properly sets up ca and ssl dir' do |action_class|
     end
   end
 
-  it 'adds default subject alt names to the master cert' do
+  it 'adds default subject alt names to the server cert' do
     Dir.mktmpdir do |tmpdir|
       with_files_in tmpdir do |bundle, key, chain, conf|
         config = default_config(conf, bundle, key, chain)
@@ -91,10 +91,10 @@ RSpec.shared_examples 'properly sets up ca and ssl dir' do |action_class|
 
         expect(exit_code).to eq(0)
 
-        master_cert_file = File.join(tmpdir, 'ssl', 'certs', 'foocert.pem')
-        expect(File.exist?(master_cert_file)).to be true
-        master_cert = OpenSSL::X509::Certificate.new(File.read(master_cert_file))
-        alt_names = master_cert.extensions.find do |ext|
+        server_cert_file = File.join(tmpdir, 'ssl', 'certs', 'foocert.pem')
+        expect(File.exist?(server_cert_file)).to be true
+        server_cert = OpenSSL::X509::Certificate.new(File.read(server_cert_file))
+        alt_names = server_cert.extensions.find do |ext|
           ext.to_s =~ /subjectAltName/
         end
 
@@ -103,7 +103,7 @@ RSpec.shared_examples 'properly sets up ca and ssl dir' do |action_class|
     end
   end
 
-  it 'adds custom subject alt names to the master cert' do
+  it 'adds custom subject alt names to the server cert' do
     Dir.mktmpdir do |tmpdir|
       with_files_in tmpdir do |bundle, key, chain, conf|
         config = default_config(conf, bundle, key, chain)
@@ -111,10 +111,10 @@ RSpec.shared_examples 'properly sets up ca and ssl dir' do |action_class|
 
         expect(exit_code).to eq(0)
 
-        master_cert_file = File.join(tmpdir, 'ssl', 'certs', 'foocert.pem')
-        expect(File.exist?(master_cert_file)).to be true
-        master_cert = OpenSSL::X509::Certificate.new(File.read(master_cert_file))
-        alt_names = master_cert.extensions.find do |ext|
+        server_cert_file = File.join(tmpdir, 'ssl', 'certs', 'foocert.pem')
+        expect(File.exist?(server_cert_file)).to be true
+        server_cert = OpenSSL::X509::Certificate.new(File.read(server_cert_file))
+        alt_names = server_cert.extensions.find do |ext|
           ext.to_s =~ /subjectAltName/
         end
 
@@ -137,7 +137,7 @@ RSpec.shared_examples 'properly sets up ca and ssl dir' do |action_class|
     end
   end
 
-  it 'honors existing master key pair when generating masters cert' do
+  it 'honors existing server key pair when generating servers cert' do
     Dir.mktmpdir do |tmpdir|
       with_files_in tmpdir do |bundle, key, chain, conf|
         private_path = File.join(tmpdir, 'ssl', 'private_keys', 'foocert.pem')
@@ -167,7 +167,7 @@ RSpec.shared_examples 'properly sets up ca and ssl dir' do |action_class|
     end
   end
 
-  it 'fails if only one of masters public, private keys are present' do
+  it 'fails if only one of servers public, private keys are present' do
     Dir.mktmpdir do |tmpdir|
       with_files_in tmpdir do |bundle, key, chain, conf|
         pkey = OpenSSL::PKey::RSA.new(512)


### PR DESCRIPTION
Update internal terminology, replacing master with server and blacklist with
denylist. The only user facing change here is updating the cli to correctly
read `serverport` from `puppet.conf` as a newer name for `masterport`.

This is a backport from main.