### PR TITLE
(SERVER-2251) Add '--verbose' flag to 'puppetserve ca' cli tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ To create a new keypair and certificate for a certname:
 puppetserver ca generate --certname foo.example.com
 ```
 
+For enabling verbose mode:
+```
+puppetserver ca --verbose <action>
+```
+
 For more details, see the help output:
 ```
 puppetserver ca --help
@@ -68,7 +73,7 @@ for more details.
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then,
-run `rake spec` to run the tests. You can also run `bin/console` for an
+run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an
 interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To create a new keypair and certificate for a certname:
 puppetserver ca generate --certname foo.example.com
 ```
 
-For enabling verbose mode:
+To enable verbose mode:
 ```
 puppetserver ca --verbose <action>
 ```

--- a/lib/puppetserver/ca/certificate_authority.rb
+++ b/lib/puppetserver/ca/certificate_authority.rb
@@ -23,7 +23,7 @@ module Puppetserver
 
       def initialize(logger, settings)
         @logger = logger
-        @client = HttpClient.new(settings)
+        @client = HttpClient.new(@logger, settings)
         @ca_server = settings[:ca_server]
         @ca_port = settings[:ca_port]
       end

--- a/lib/puppetserver/ca/cli.rb
+++ b/lib/puppetserver/ca/cli.rb
@@ -64,8 +64,9 @@ BANNER
 
 
       def self.run(cli_args = ARGV, out = STDOUT, err = STDERR)
-        logger = Puppetserver::Ca::Logger.new(:info, out, err)
         parser, general_options, unparsed = parse_general_inputs(cli_args)
+        logger = general_options.key?('verbose') ? Puppetserver::Ca::Logger.new(:debug, out, err)
+                                                    : Puppetserver::Ca::Logger.new(:info, out, err)
 
         if general_options['version']
           logger.inform Puppetserver::Ca::VERSION
@@ -120,6 +121,9 @@ BANNER
           end
           opts.on('--version', 'Display the version') do |v|
             parsed['version'] = true
+          end
+          opts.on('--verbose', 'Display low-level information') do |verbose|
+            parsed['verbose'] = true
           end
 
           opts.separator ACTION_OPTIONS

--- a/lib/puppetserver/ca/cli.rb
+++ b/lib/puppetserver/ca/cli.rb
@@ -65,8 +65,9 @@ BANNER
 
       def self.run(cli_args = ARGV, out = STDOUT, err = STDERR)
         parser, general_options, unparsed = parse_general_inputs(cli_args)
-        logger = general_options.key?('verbose') ? Puppetserver::Ca::Logger.new(:debug, out, err)
-                                                    : Puppetserver::Ca::Logger.new(:info, out, err)
+        level = general_options.delete('verbose') ? :debug : :info
+
+        logger = Puppetserver::Ca::Logger.new(level, out, err)
 
         if general_options['version']
           logger.inform Puppetserver::Ca::VERSION

--- a/lib/puppetserver/ca/logger.rb
+++ b/lib/puppetserver/ca/logger.rb
@@ -13,6 +13,10 @@ module Puppetserver
         @err = err
       end
 
+      def level
+        @level
+      end
+
       def debug(text)
         if @level >= LEVELS[:debug]
           @out.puts(text)

--- a/lib/puppetserver/ca/utils/http_client.rb
+++ b/lib/puppetserver/ca/utils/http_client.rb
@@ -96,23 +96,24 @@ module Puppetserver
             url = url_overide || @url
             headers = DEFAULT_HEADERS.merge(headers)
 
+            @logger.debug("Making a GET request at #{url}")
+
             request = Net::HTTP::Get.new(url.to_uri, headers)
             result = @conn.request(request)
-            
-            @logger.debug("Making a get request at url #{url}")
-
             Result.new(result.code, result.body)
+
           end
 
           def put(body, url_override = nil, headers = {})
             url = url_override || @url
             headers = DEFAULT_HEADERS.merge(headers)
 
+            @logger.debug("Making a PUT request at #{url}")
+
             request = Net::HTTP::Put.new(url.to_uri, headers)
             request.body = body
             result = @conn.request(request)
 
-            @logger.debug("Making a put request at url #{url}")
 
             Result.new(result.code, result.body)
           end
@@ -121,9 +122,9 @@ module Puppetserver
             url = url_override || @url
             headers = DEFAULT_HEADERS.merge(headers)
 
-            result = @conn.request(Net::HTTP::Delete.new(url.to_uri, headers))
+            @logger.debug("Making a DELETE request at #{url}")
 
-            @logger.debug("Making a delete request at url #{url}")
+            result = @conn.request(Net::HTTP::Delete.new(url.to_uri, headers))
 
             Result.new(result.code, result.body)
           end

--- a/spec/puppetserver/ca/cli_spec.rb
+++ b/spec/puppetserver/ca/cli_spec.rb
@@ -58,16 +58,15 @@ RSpec.describe Puppetserver::Ca::Cli do
       /.*Usage.* puppetserver ca sign.*Display this command-specific help output.*/m
   end
 
-  #This test is not specific for clean, but just an action to validate our test
-  #would work with other options as well.
+  # This test is a representation of what to expect when the verbose flag
+  # is raised with an action. We're using the 'clean' action as an example 
   it 'raise the verbose flag' do
     args = ['--verbose', 'clean'].compact
     action_class = Puppetserver::Ca::Cli::VALID_ACTIONS[args[1]]
-    expect(action_class).to receive(:new).and_wrap_original  do |original, logger|
+    expect(action_class).to receive(:new).and_wrap_original do |original, logger|
       expect(logger.level).to eq(4)
       original.call(logger)
     end
     Puppetserver::Ca::Cli.run(args, StringIO.new, StringIO.new)
   end
-
 end

--- a/spec/puppetserver/ca/cli_spec.rb
+++ b/spec/puppetserver/ca/cli_spec.rb
@@ -57,4 +57,17 @@ RSpec.describe Puppetserver::Ca::Cli do
       'sign',
       /.*Usage.* puppetserver ca sign.*Display this command-specific help output.*/m
   end
+
+  #This test is not specific for clean, but just an action to validate our test
+  #would work with other options as well.
+  it 'raise the verbose flag' do
+    args = ['--verbose', 'clean'].compact
+    action_class = Puppetserver::Ca::Cli::VALID_ACTIONS[args[1]]
+    expect(action_class).to receive(:new).and_wrap_original  do |original, logger|
+      expect(logger.level).to eq(4)
+      original.call(logger)
+    end
+    Puppetserver::Ca::Cli.run(args, StringIO.new, StringIO.new)
+  end
+
 end

--- a/spec/puppetserver/ca/utils/http_client_spec.rb
+++ b/spec/puppetserver/ca/utils/http_client_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Puppetserver::Ca::Utils::HttpClient do
     FileUtils.cp(settings[:cacert], settings[:localcacert])
     FileUtils.cp(settings[:cacrl], settings[:hostcrl])
 
-    client = Puppetserver::Ca::Utils::HttpClient.new(settings)
+    client = Puppetserver::Ca::Utils::HttpClient.new(logger, settings) 
     store = client.store
 
     expect(store.verify(hostcert)).to be(true)

--- a/spec/shared_examples/cli_parsing.rb
+++ b/spec/shared_examples/cli_parsing.rb
@@ -17,12 +17,4 @@ RSpec.shared_examples 'basic cli args' do |action, usage|
     expect(stderr.string).to be_empty
     expect(first_code).to be 0
   end
-
-  it 'raise the verbose flag' do
-    args = ['--verbose', action].compact
-    _,parsed,_ = Puppetserver::Ca::Cli.parse_general_inputs(args)
-    expect(parsed['verbose']).to be true
-    logger = Puppetserver::Ca::Logger.new(:debug, stdout, stderr)
-    expect(logger.level).to be Puppetserver::Ca::Logger::LEVELS[:debug]
-  end
 end

--- a/spec/shared_examples/cli_parsing.rb
+++ b/spec/shared_examples/cli_parsing.rb
@@ -17,4 +17,12 @@ RSpec.shared_examples 'basic cli args' do |action, usage|
     expect(stderr.string).to be_empty
     expect(first_code).to be 0
   end
+
+  it 'raise the verbose flag' do
+    args = ['--verbose', action].compact
+    _,parsed,_ = Puppetserver::Ca::Cli.parse_general_inputs(args)
+    expect(parsed['verbose']).to be true
+    logger = Puppetserver::Ca::Logger.new(:debug, stdout, stderr)
+    expect(logger.level).to be Puppetserver::Ca::Logger::LEVELS[:debug]
+  end
 end


### PR DESCRIPTION
There are more changes like adding the logger to certain methods in `http_client.rb` but I elected not to include that in this PR.