### PR TITLE
(SERVER-3006) Provide parsable (json) output for puppetserver ca commands

### DIFF
--- a/lib/puppetserver/ca/action/list.rb
+++ b/lib/puppetserver/ca/action/list.rb
@@ -64,12 +64,12 @@ Options:
           output_format = input['format'] || "text"
           
           unless VALID_FORMAT.include?(output_format)
-            Errors.handle_with_usage(@logger, ["Unknown format flag '#{output_format}'. Valid formats are '#{VALID_FORMAT.join("', '")}'"])
+            Errors.handle_with_usage(@logger, ["Unknown format flag '#{output_format}'. Valid formats are '#{VALID_FORMAT.join("', '")}'."])
             return 1
           end 
 
           if all && certnames.any?
-            Errors.handle_with_usage(@logger, ['Cannot combine use of --all and --certname'])
+            Errors.handle_with_usage(@logger, ['Cannot combine use of --all and --certname.'])
             return 1
           end
 
@@ -107,33 +107,33 @@ Options:
         end
 
         def output_certs_json_format(all, requested, signed, revoked, missing)
-          if revoked.empty? && signed.empty? && requested.empty? && missing.empty?
-            @logger.inform([].to_json)
-            return
-          end
+          grouped_cert = {}
 
           if all
             grouped_cert = { "requested" => requested,
                              "signed" => signed,
-                             "revoked" => revoked,
-                             "missing" => missing }.to_json
+                             "revoked" => revoked }.to_json
             @logger.inform(grouped_cert)
           else
             unless requested.empty?
-              @logger.inform(requested.to_json)
+              grouped_cert["requested"] = requested
             end
 
             unless signed.empty?
-              @logger.inform(signed.to_json)
+              grouped_cert["signed"] = signed
             end
 
             unless revoked.empty?
-              @logger.inform(revoked.to_json)
+              grouped_cert["revoked"] = revoked
             end
 
             unless missing.empty?
-              @logger.inform(missing.to_json)
+              grouped_cert["missing"] = missing
             end
+
+            grouped_cert.empty? \
+            ? @logger.inform({ "requested" => requested }.to_json) 
+            : @logger.inform(grouped_cert.to_json)
           end
         end
 

--- a/spec/puppetserver/ca/action/list_spec.rb
+++ b/spec/puppetserver/ca/action/list_spec.rb
@@ -77,14 +77,21 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
       allow(action).to receive(:get_all_certs).and_return(result)
       exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'json'})
       expect(exit_code).to eq(0)
-      expect(out.string).to match(/\{.*"name\":\"foo\".*\"fingerprints\".*\}/) 
+      expect(out.string).to match(/\{.*"name\":\"baz\".*\"fingerprints\".*\}.*.\{.*"name\":\"foo\".*\}/) 
+    end
+
+    it 'does not throw error when text format option is passed in' do
+      allow(action).to receive(:get_all_certs).and_return(result)
+      exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'text'})
+      expect(exit_code).to eq(0)
+      expect(out.string).to match(/Signed Certificates:.*foo.*\(SHA256\).*three.*alt names:.*"DNS:foo", "DNS:bar".*/m)
     end
 
     it 'returns the correct output, including empty keys with the --all option' do
       allow(action).to receive(:get_all_certs).and_return(result)
       exit_code = action.run({'all' => true, 'format' => 'json'})
       expect(exit_code).to eq(0)
-      expect(out.string).to match(/\{.*"requested\".*\}.*.\{.*"signed\".*\}.*.\{.*"revoked\".*\}.*.\{.*"missing\".*\}/)
+      expect(out.string).to match(/\{.*"requested\".*\}.*.\{.*"signed\".*\}.*.\{.*"revoked\".*\}/)
     end
   end
 end

--- a/spec/puppetserver/ca/action/list_spec.rb
+++ b/spec/puppetserver/ca/action/list_spec.rb
@@ -66,5 +66,25 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
       expect(out.string).to match(/Signed Certificates:.*foo.*\(SHA256\).*three.*alt names:.*"DNS:foo", "DNS:bar".*/m)
       expect(out.string).to match(/Missing Certificates:.*fake.*/m)
     end
+
+    it 'errors when unknown format option is passed in' do
+      allow(action).to receive(:get_all_certs).and_return(result)
+      exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'test'})
+      expect(exit_code).to eq(1)
+    end
+
+    it 'does not throw error when json format option is passed in' do
+      allow(action).to receive(:get_all_certs).and_return(result)
+      exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'json'})
+      expect(exit_code).to eq(0)
+      expect(out.string).to match(/\{.*"name\":\"foo\".*\"fingerprints\".*\}/) 
+    end
+
+    it 'returns the correct output, including empty keys with the --all option' do
+      allow(action).to receive(:get_all_certs).and_return(result)
+      exit_code = action.run({'all' => true, 'format' => 'json'})
+      expect(exit_code).to eq(0)
+      expect(out.string).to match(/\{.*"requested\".*\}.*.\{.*"signed\".*\}.*.\{.*"revoked\".*\}.*.\{.*"missing\".*\}/)
+    end
   end
 end


### PR DESCRIPTION
Here's a sample output in JSON format execute by `list --certname tu --format json | python -m json.tool` (Piped through python for pretty print)
```
[
    {
        "authorization_extensions": {},
        "dns_alt_names": [
            "DNS:tu"
        ],
        "fingerprint": "18:52:07:6E:6F:E0:42:40:20:75:B8:80:0F:5D:26:94:0A:22:DC:2A:DD:67:81:90:BA:B3:13:8D:AD:B3:B5:95",
        "fingerprints": {
            "SHA1": "74:6F:63:4B:94:0B:EE:EE:1F:D9:60:DD:36:9D:E8:76:6C:A0:38:F7",
            "SHA256": "18:52:07:6E:6F:E0:42:40:20:75:B8:80:0F:5D:26:94:0A:22:DC:2A:DD:67:81:90:BA:B3:13:8D:AD:B3:B5:95",
            "SHA512": "F7:0D:4E:C0:8C:A8:8A:8C:2B:5B:49:27:63:EB:39:C5:26:B7:DB:28:E8:7D:63:DD:E1:BF:E8:B6:06:A4:28:44:48:FD:81:89:EB:37:7E:54:12:9C:4D:1C:EC:63:63:A4:70:11:E8:08:F1:90:F5:B2:6C:99:CE:6A:03:C5:7A:4A",
            "default": "18:52:07:6E:6F:E0:42:40:20:75:B8:80:0F:5D:26:94:0A:22:DC:2A:DD:67:81:90:BA:B3:13:8D:AD:B3:B5:95"
        },
        "name": "tu",
        "not_after": "2026-06-28T19:18:10UTC",
        "not_before": "2021-06-28T19:18:10UTC",
        "serial_number": 3,
        "state": "revoked",
        "subject_alt_names": [
            "DNS:tu"
        ]
    }
]
```