### PR TITLE
Merge 1.x to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ To create a new keypair and certificate for a certname:
 puppetserver ca generate --certname foo.example.com
 ```
 
+To enable verbose mode:
+```
+puppetserver ca --verbose <action>
+```
+
 For more details, see the help output:
 ```
 puppetserver ca --help
@@ -68,7 +73,7 @@ for more details.
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then,
-run `rake spec` to run the tests. You can also run `bin/console` for an
+run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an
 interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`.
@@ -93,6 +98,7 @@ To test your changes on a VM:
 
 ### Releasing
 To release a new version, run the [release pipeline](https://jenkins-master-prod-1.delivery.puppetlabs.net/job/platform_puppetserver-ca_init-multijob_main/), which will bump the version, tag, build, and release the gem.
+To release a new version, run the [release pipeline](https://jenkins-platform.delivery.puppetlabs.net/job/platform_puppetserver-ca_init-multijob_1.x/), which will bump the version, tag, build, and release the gem.
 
 
 ## Contributing & Support

--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ To test your changes on a VM:
 
 ### Releasing
 To release a new version, run the [release pipeline](https://jenkins-master-prod-1.delivery.puppetlabs.net/job/platform_puppetserver-ca_init-multijob_main/), which will bump the version, tag, build, and release the gem.
-To release a new version, run the [release pipeline](https://jenkins-platform.delivery.puppetlabs.net/job/platform_puppetserver-ca_init-multijob_1.x/), which will bump the version, tag, build, and release the gem.
-
 
 ## Contributing & Support
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To test your changes on a VM:
 1. To confirm that installation was successful, run `puppetserver ca --help`
 
 ### Releasing
-To release a new version, run the [release pipeline](https://jenkins-master-prod-1.delivery.puppetlabs.net/job/platform_puppetserver-ca_init-multijob_main/), which will bump the version, tag, build, and release the gem.
+To release a new version, run the [release pipeline](https://jenkins-platform.delivery.puppetlabs.net/job/platform_puppetserver-ca_init-multijob_main/), which will bump the version, tag, build, and release the gem.
 
 ## Contributing & Support
 

--- a/lib/puppetserver/ca/action/list.rb
+++ b/lib/puppetserver/ca/action/list.rb
@@ -30,6 +30,7 @@ Options:
       BANNER
 
         BODY = JSON.dump({desired_state: 'signed'})
+        VALID_FORMAT = ['text', 'json']
 
         def initialize(logger)
           @logger = logger
@@ -47,6 +48,9 @@ Options:
             opts.on('--all', 'List all certificates') do |a|
               parsed['all'] = true
             end
+            opts.on('--format FORMAT', "Valid formats are: 'text' (default), 'json'") do |f|
+              parsed['format'] = f
+            end
             opts.on('--certname NAME[,NAME]', Array, 'List the specified cert(s)') do |cert|
               parsed['certname'] = cert
             end
@@ -57,9 +61,15 @@ Options:
           config = input['config']
           certnames = input['certname'] || []
           all = input['all']
+          output_format = input['format'] || "text"
+
+          unless VALID_FORMAT.include?(output_format)
+            Errors.handle_with_usage(@logger, ["Unknown format flag '#{output_format}'. Valid formats are '#{VALID_FORMAT.join("', '")}'."])
+            return 1
+          end
 
           if all && certnames.any?
-            Errors.handle_with_usage(@logger, ['Cannot combine use of --all and --certname'])
+            Errors.handle_with_usage(@logger, ['Cannot combine use of --all and --certname.'])
             return 1
           end
 
@@ -71,24 +81,60 @@ Options:
           puppet = Config::Puppet.parse(config, @logger)
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 
-          filter_names = certnames.any? \
-            ? lambda { |x| certnames.include?(x['name']) }
-            : lambda { |x| true }
+          if certnames.any?
+            filter_names = lambda { |x| certnames.include?(x['name']) }
+          else
+            filter_names = lambda { |x| true }
+          end
 
           all_certs = get_all_certs(puppet.settings).select { |cert| filter_names.call(cert) }
           requested, signed, revoked = separate_certs(all_certs)
           missing = certnames - all_certs.map { |cert| cert['name'] }
 
-          (all || certnames.any?) \
-            ? output_certs_by_state(requested, signed, revoked, missing)
-            : output_certs_by_state(requested)
+          if (all || certnames.any?)
+            output_certs_by_state(all, output_format, requested, signed, revoked, missing)
+          else
+            output_certs_by_state(all, output_format, requested)
+          end
 
-          return missing.any? \
-            ? 1
-            : 0
+          return missing.any? ? 1 : 0
         end
 
-        def output_certs_by_state(requested, signed = [], revoked = [], missing = [])
+        def output_certs_by_state(all, output_format, requested, signed = [], revoked = [], missing = [])
+          if output_format == 'json'
+            output_certs_json_format(all, requested, signed, revoked, missing)
+          else
+            output_certs_text_format(requested, signed, revoked, missing)
+          end
+        end
+
+        def output_certs_json_format(all, requested, signed, revoked, missing)
+          grouped_cert = {}
+
+          if all
+            grouped_cert = { "requested" => requested,
+                             "signed" => signed,
+                             "revoked" => revoked }.to_json
+            @logger.inform(grouped_cert)
+          else
+            grouped_cert["requested"] = requested unless requested.empty?
+            grouped_cert["signed"] = signed unless signed.empty?
+            grouped_cert["revoked"] = revoked unless revoked.empty?
+            grouped_cert["missing"] = missing unless missing.empty?
+
+            # If neither the '--all' flag or the '--certname' flag was passed in
+            # and the requested cert array is empty, we output a JSON object
+            # with an empty 'requested' key. Otherwise, we display
+            # any of the classes that are currently in grouped_cert
+            if grouped_cert.empty?
+              @logger.inform({ "requested" => requested }.to_json)
+            else
+              @logger.inform(grouped_cert.to_json)
+            end
+          end
+        end
+
+        def output_certs_text_format(requested, signed, revoked, missing)
           if revoked.empty? && signed.empty? && requested.empty? && missing.empty?
             @logger.inform "No certificates to list"
             return
@@ -165,7 +211,12 @@ Options:
 
         def get_all_certs(settings)
           result = Puppetserver::Ca::CertificateAuthority.new(@logger, settings).get_certificate_statuses
-          result ? JSON.parse(result.body) : []
+
+          if result
+            return JSON.parse(result.body)
+          else
+            return []
+          end
         end
 
         def parse(args)
@@ -176,8 +227,11 @@ Options:
 
           errors_were_handled = Errors.handle_with_usage(@logger, errors, parser.help)
 
-          exit_code = errors_were_handled ? 1 : nil
-
+          if errors_were_handled
+            exit_code = 1
+          else
+            exit_code = nil
+          end
           return results, exit_code
         end
       end

--- a/lib/puppetserver/ca/certificate_authority.rb
+++ b/lib/puppetserver/ca/certificate_authority.rb
@@ -23,7 +23,7 @@ module Puppetserver
 
       def initialize(logger, settings)
         @logger = logger
-        @client = HttpClient.new(settings)
+        @client = HttpClient.new(@logger, settings)
         @ca_server = settings[:ca_server]
         @ca_port = settings[:ca_port]
       end

--- a/lib/puppetserver/ca/cli.rb
+++ b/lib/puppetserver/ca/cli.rb
@@ -64,8 +64,10 @@ BANNER
 
 
       def self.run(cli_args = ARGV, out = STDOUT, err = STDERR)
-        logger = Puppetserver::Ca::Logger.new(:info, out, err)
         parser, general_options, unparsed = parse_general_inputs(cli_args)
+        level = general_options.delete('verbose') ? :debug : :info
+
+        logger = Puppetserver::Ca::Logger.new(level, out, err)
 
         if general_options['version']
           logger.inform Puppetserver::Ca::VERSION
@@ -120,6 +122,9 @@ BANNER
           end
           opts.on('--version', 'Display the version') do |v|
             parsed['version'] = true
+          end
+          opts.on('--verbose', 'Display low-level information') do |verbose|
+            parsed['verbose'] = true
           end
 
           opts.separator ACTION_OPTIONS

--- a/lib/puppetserver/ca/logger.rb
+++ b/lib/puppetserver/ca/logger.rb
@@ -13,6 +13,10 @@ module Puppetserver
         @err = err
       end
 
+      def level
+        @level
+      end
+
       def debug(text)
         if @level >= LEVELS[:debug]
           @out.puts(text)

--- a/spec/puppetserver/ca/action/list_spec.rb
+++ b/spec/puppetserver/ca/action/list_spec.rb
@@ -1,6 +1,7 @@
 require 'puppetserver/ca/action/list'
 require 'puppetserver/ca/cli'
 require 'puppetserver/ca/logger'
+require 'json'
 
 RSpec.describe 'Puppetserver::Ca::Action::List' do
   let(:err)    { StringIO.new }
@@ -65,6 +66,49 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
       expect(exit_code).to eq(1)
       expect(out.string).to match(/Signed Certificates:.*foo.*\(SHA256\).*three.*alt names:.*"DNS:foo", "DNS:bar".*/m)
       expect(out.string).to match(/Missing Certificates:.*fake.*/m)
+    end
+
+    it 'errors when unknown format option is passed in' do
+      allow(action).to receive(:get_all_certs).and_return(result)
+      exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'test'})
+      expect(exit_code).to eq(1)
+    end
+
+    it 'does not throw error when json format option is passed in' do
+      allow(action).to receive(:get_all_certs).and_return(result)
+      exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'json'})
+      expect(exit_code).to eq(0)
+      parsed_output = JSON.parse(out.string)
+      expect(parsed_output).to be_a_kind_of(Hash)
+      expect(parsed_output).to have_key("signed")
+      expect(parsed_output).to have_key("requested")
+    end
+
+    it 'does not throw error when text format option is passed in' do
+      allow(action).to receive(:get_all_certs).and_return(result)
+      exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'text'})
+      expect(exit_code).to eq(0)
+      expect(out.string).to match(/Signed Certificates:.*foo.*\(SHA256\).*three.*alt names:.*"DNS:foo", "DNS:bar".*/m)
+    end
+
+    it 'returns the correct output, including empty keys with the --all option' do
+      allow(action).to receive(:get_all_certs).and_return(result)
+      exit_code = action.run({'all' => true, 'format' => 'json'})
+      expect(exit_code).to eq(0)
+      parsed_output = JSON.parse(out.string)
+      expect(parsed_output).to be_a_kind_of(Hash)
+      expect(parsed_output).to have_key("signed")
+      expect(parsed_output).to have_key("requested")
+      expect(parsed_output).to have_key("revoked")
+    end
+
+    it 'output the non-existent cert as a JSON object with the missing key' do
+      allow(action).to receive(:get_all_certs).and_return(result)
+      exit_code = action.run({'certname' => ['pup'], 'format' => 'json'})
+      expect(exit_code).to eq(1)
+      parsed_output = JSON.parse(out.string)
+      expect(parsed_output).to be_a_kind_of(Hash)
+      expect(parsed_output).to have_key("missing")
     end
   end
 end

--- a/spec/puppetserver/ca/cli_spec.rb
+++ b/spec/puppetserver/ca/cli_spec.rb
@@ -57,4 +57,16 @@ RSpec.describe Puppetserver::Ca::Cli do
       'sign',
       /.*Usage.* puppetserver ca sign.*Display this command-specific help output.*/m
   end
+
+  # This test is a representation of what to expect when the verbose flag
+  # is raised with an action. We're using the 'clean' action as an example 
+  it 'raise the verbose flag' do
+    args = ['--verbose', 'clean'].compact
+    action_class = Puppetserver::Ca::Cli::VALID_ACTIONS[args[1]]
+    expect(action_class).to receive(:new).and_wrap_original do |original, logger|
+      expect(logger.level).to eq(4)
+      original.call(logger)
+    end
+    Puppetserver::Ca::Cli.run(args, StringIO.new, StringIO.new)
+  end
 end

--- a/spec/puppetserver/ca/utils/http_client_spec.rb
+++ b/spec/puppetserver/ca/utils/http_client_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Puppetserver::Ca::Utils::HttpClient do
       FileUtils.cp(settings[:cacert], settings[:localcacert])
       FileUtils.cp(settings[:cacrl], settings[:hostcrl])
 
-      client = Puppetserver::Ca::Utils::HttpClient.new(settings)
+      client = Puppetserver::Ca::Utils::HttpClient.new(logger, settings)
       store = client.store
 
       expect(store.verify(hostcert)).to be(true)


### PR DESCRIPTION
Puppetserver-ca CLI now has a verbose option that can be trigger by using the '--verbose' flag.  It can also output certificate depends on the user's choice of format.  As of now, the supported format are: text (default) and JSON.