### PR TITLE
(SERVER-2740) Fix how CRL number is updated

### DIFF
--- a/lib/puppetserver/ca/action/prune.rb
+++ b/lib/puppetserver/ca/action/prune.rb
@@ -80,7 +80,12 @@ BANNER
 
         def update_pruned_CRL(crl_list, pkey)
           crl_list.each do |crl|
-            crl.version=(crl.version + 1)
+            extension_key = crl.extensions.select { |ext| ext.oid != "crlNumber" }
+            extension_number = crl.extensions.select { |ext| ext.oid == "crlNumber" }
+            extension_number.each do |crl_number|
+              crl_number.value=((crl_number.value.to_i + 1).to_s)
+            end
+            crl.extensions=(extension_number + extension_key)
             crl.sign(pkey, OpenSSL::Digest::SHA256.new)
           end
         end

--- a/spec/puppetserver/ca/action/prune_spec.rb
+++ b/spec/puppetserver/ca/action/prune_spec.rb
@@ -76,8 +76,9 @@ RSpec.describe Puppetserver::Ca::Action::Prune do
       revoked_cert = create_cert(ca_key, 'revoked')
       ca_crl = create_crl(ca_cert, ca_key, Array.new(5, revoked_cert))
 
-      subject.prune_CRLs([ca_crl])
+      number_of_removed_duplicates = subject.prune_CRLs([ca_crl])
       expect(ca_crl.revoked.length).to eq(1)
+      expect(number_of_removed_duplicates).to eq(4)
     end
 
     it 'deduplicates a CRL with multiple certs that have duplicate of themselves' do
@@ -89,8 +90,9 @@ RSpec.describe Puppetserver::Ca::Action::Prune do
 
       ca_crl = create_crl(ca_cert, ca_key, first_cert + second_cert + third_cert)
 
-      subject.prune_CRLs([ca_crl])
+      number_of_removed_duplicates = subject.prune_CRLs([ca_crl])
       expect(ca_crl.revoked.length).to eq(3)
+      expect(number_of_removed_duplicates).to eq(15)
     end
   end
 

--- a/spec/puppetserver/ca/action/prune_spec.rb
+++ b/spec/puppetserver/ca/action/prune_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Puppetserver::Ca::Action::Prune do
 
       extensions = ca_crl.extensions.select { |ext| ext.oid == "crlNumber"}
       extensions.each do |ext|
-        expect(ext.value).to match("1")
+        expect(ext.value).to eq("1")
       end
     end
   end

--- a/spec/puppetserver/ca/action/prune_spec.rb
+++ b/spec/puppetserver/ca/action/prune_spec.rb
@@ -95,13 +95,17 @@ RSpec.describe Puppetserver::Ca::Action::Prune do
   end
 
   describe 'update' do
-    it 'bumps CRL version up by 1' do
+    it 'bumps CRL number up by 1' do
       ca_key = OpenSSL::PKey::RSA.new(512)
       ca_cert = create_cert(ca_key, "Bazzup")
       ca_crl = create_crl(ca_cert, ca_key)
 
       subject.update_pruned_CRL([ca_crl], ca_key)
-      expect(ca_crl.version).to eq(2)
+
+      extensions = ca_crl.extensions.select { |ext| ext.oid == "crlNumber"}
+      extensions.each do |ext|
+        expect(ext.value).to match("1")
+      end
     end
   end
 end


### PR DESCRIPTION
This commit contains a fix to the prune action so that the CRL number is properly updated after pruning.  Before, the code would update the protocol version which is incorrect.