### PR TITLE
Merge 1.x to main

### DIFF
--- a/lib/puppetserver/ca/action/prune.rb
+++ b/lib/puppetserver/ca/action/prune.rb
@@ -50,15 +50,22 @@ BANNER
           loader = X509Loader.new(puppet.settings[:cacert], puppet.settings[:cakey], puppet.settings[:cacrl])
 
           puppet_crl = loader.crls.select { |crl| crl.verify(loader.key) }
-          prune_CRLs(puppet_crl)
-          update_pruned_CRL(puppet_crl, loader.key)
-          FileSystem.write_file(puppet.settings[:cacrl], loader.crls, 0644)
+          number_of_removed_duplicates = prune_CRLs(puppet_crl)
 
-          @logger.inform("Finished pruning Puppet's CRL")
+          if number_of_removed_duplicates > 0
+            update_pruned_CRL(puppet_crl, loader.key)
+            FileSystem.write_file(puppet.settings[:cacrl], loader.crls, 0644)
+            @logger.inform("Removed #{number_of_removed_duplicates} duplicated certs from Puppet's CRL.")
+          else
+            @logger.inform("No duplicate revocations found in the CRL.")
+          end
+
           return 0
         end
 
         def prune_CRLs(crl_list)
+          number_of_removed_duplicates = 0
+
           crl_list.each do |crl|
             existed_serial_number = Set.new()
             revoked_list = crl.revoked
@@ -69,6 +76,7 @@ BANNER
               if existed_serial_number.add?(revoked.serial)
                 false
               else
+                number_of_removed_duplicates += 1
                 @logger.debug("Removing duplicate of #{revoked.serial}, " \
                   "revoked on #{revoked.time}\n") if @logger.debug?
                 true
@@ -76,11 +84,18 @@ BANNER
             end
             crl.revoked=(revoked_list)
           end
+
+          return number_of_removed_duplicates
         end
 
         def update_pruned_CRL(crl_list, pkey)
           crl_list.each do |crl|
-            crl.version=(crl.version + 1)
+            number_ext, other_ext = crl.extensions.partition{ |ext| ext.oid == "crlNumber" }
+            number_ext.each do |crl_number|
+              updated_crl_number = OpenSSL::BN.new(crl_number.value) + OpenSSL::BN.new(1)
+              crl_number.value=(OpenSSL::ASN1::Integer(updated_crl_number))
+            end
+            crl.extensions=(number_ext + other_ext)
             crl.sign(pkey, OpenSSL::Digest::SHA256.new)
           end
         end


### PR DESCRIPTION
This PR include bug fixes and changes made to the prune action.  
As for bug fixes:
   - Correctly update the CRL number after pruning instead of updating the CRL protocol number.

As for changes made:
   - Make sure that the CRL does not update if nothing happened when pruning (i.e no duplicated certs)
   - Report back to the user the number of duplicated certs pruned from the CRL.  