### PR TITLE
(SERVER-2509) Update output message for revoke action

### DIFF
--- a/lib/puppetserver/ca/certificate_authority.rb
+++ b/lib/puppetserver/ca/certificate_authority.rb
@@ -141,7 +141,7 @@ module Puppetserver
         when :revoke
           case result.code
           when '200', '204'
-            @logger.inform "Revoked certificate for #{certname}"
+            @logger.inform "Certificate for #{certname} has been revoked"
             return :success
           when '404'
             @logger.err 'Error:'
@@ -215,7 +215,7 @@ module Puppetserver
       def check_revocation(certname, result)
         case result.code
         when '200', '204'
-          @logger.inform "Revoked certificate for #{certname}"
+          @logger.inform "Certificate for #{certname} has been revoked"
           return :success
         when '409'
           return :invalid

--- a/spec/puppetserver/ca/action/clean_spec.rb
+++ b/spec/puppetserver/ca/action/clean_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Puppetserver::Ca::Action::Clean do
 
       code = subject.run({'certnames' => ['foo']})
       expect(code).to eq(0)
-      expect(stdout.string).to match(/Revoked.*foo/)
+      expect(stdout.string).to match(/Certificate.*foo/)
       expect(stdout.string).to include('Cleaned files related to foo')
       expect(stderr.string).to be_empty
     end

--- a/spec/puppetserver/ca/action/revoke_spec.rb
+++ b/spec/puppetserver/ca/action/revoke_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Puppetserver::Ca::Action::Revoke do
 
       code = subject.run({'certnames' => ['foo']})
       expect(code).to eq(0)
-      expect(stdout.string.chomp).to eq('Revoked certificate for foo')
+      expect(stdout.string.chomp).to eq('Certificate for foo has been revoked')
       expect(stderr.string).to be_empty
     end
 
@@ -78,7 +78,7 @@ RSpec.describe Puppetserver::Ca::Action::Revoke do
 
       code = subject.run({'certnames' => ['foo', 'bar']})
       expect(code).to eq(1)
-      expect(stdout.string.chomp).to eq('Revoked certificate for bar')
+      expect(stdout.string.chomp).to eq('Certificate for bar has been revoked')
       expect(stderr.string).to match(/Error.*not find certificate for foo/m)
     end
 
@@ -88,7 +88,7 @@ RSpec.describe Puppetserver::Ca::Action::Revoke do
 
       code = subject.run({'certnames' => ['foo', 'bar']})
       expect(code).to eq(24)
-      expect(stdout.string.chomp).to eq('Revoked certificate for bar')
+      expect(stdout.string.chomp).to eq('Certificate for bar has been revoked')
       expect(stderr.string).to match(/Error.*not revoke unsigned csr for foo/m)
     end
 
@@ -99,7 +99,7 @@ RSpec.describe Puppetserver::Ca::Action::Revoke do
 
       code = subject.run({'certnames' => ['foo', 'bar', 'baz']})
       expect(code).to eq(1)
-      expect(stdout.string.chomp).to eq('Revoked certificate for bar')
+      expect(stdout.string.chomp).to eq('Certificate for bar has been revoked')
       expect(stderr.string).to match(/Error.*not revoke unsigned csr for baz/m)
       expect(stderr.string).to match(/Error.*not find certificate for foo/m)
     end
@@ -110,7 +110,7 @@ RSpec.describe Puppetserver::Ca::Action::Revoke do
 
       code = subject.run({'certnames' => ['foo', 'bar']})
       expect(code).to eq(1)
-      expect(stdout.string.chomp).to eq('Revoked certificate for bar')
+      expect(stdout.string.chomp).to eq('Certificate for bar has been revoked')
       expect(stderr.string).
         to match(/Error.*attempting to revoke.*code: 500.*body: Internal Server Error/m)
     end


### PR DESCRIPTION
Update the output message upon revoking a certificate, whether that cert is signed or revoked, to convey a more reassuring tone that the action is successful.