### PR TITLE
(SERVER-3060) Improve speed when querying for CSR only

### DIFF
--- a/lib/puppetserver/ca/certificate_authority.rb
+++ b/lib/puppetserver/ca/certificate_authority.rb
@@ -41,8 +41,8 @@ module Puppetserver
       end
 
       # Returns a URI-like wrapper around CA specific urls
-      def make_ca_url(resource_type = nil, certname = nil)
-        HttpClient::URL.new('https', @ca_server, @ca_port, 'puppet-ca', 'v1', resource_type, certname)
+      def make_ca_url(resource_type = nil, certname = nil, query = {})
+        HttpClient::URL.new('https', @ca_server, @ca_port, 'puppet-ca', 'v1', resource_type, certname, query)
       end
 
       def process_ttl_input(ttl)
@@ -250,8 +250,8 @@ module Puppetserver
       end
 
       # Returns nil for errors, else the result of the GET request
-      def get_certificate_statuses
-        result = get('certificate_statuses', 'any_key')
+      def get_certificate_statuses(query = {})
+        result = get('certificate_statuses', 'any_key', query)
 
         unless result.code == '200'
           @logger.err 'Error:'
@@ -287,8 +287,8 @@ module Puppetserver
       # @param resource_type [String] the resource type of url
       # @param resource_name [String] the resource name of url
       # @return [Struct] an instance of the Result struct with :code, :body
-      def get(resource_type, resource_name)
-        url = make_ca_url(resource_type, resource_name)
+      def get(resource_type, resource_name, query = {})
+        url = make_ca_url(resource_type, resource_name, query)
         @client.with_connection(url) do |connection|
           connection.get(url)
         end

--- a/lib/puppetserver/ca/utils/http_client.rb
+++ b/lib/puppetserver/ca/utils/http_client.rb
@@ -1,5 +1,6 @@
 require 'net/https'
 require 'openssl'
+require 'uri'
 
 require 'puppetserver/ca/errors'
 
@@ -114,7 +115,6 @@ module Puppetserver
             request.body = body
             result = @conn.request(request)
 
-
             Result.new(result.code, result.body)
           end
 
@@ -136,10 +136,13 @@ module Puppetserver
         # Like URI, but not... maybe of suspicious value
         URL = Struct.new(:protocol, :host, :port,
                          :endpoint, :version,
-                         :resource_type, :resource_name) do
+                         :resource_type, :resource_name, :query) do
                 def full_url
-                  protocol + '://' + host + ':' + port + '/' +
-                  [endpoint, version, resource_type, resource_name].join('/')
+                  url = protocol + '://' + host + ':' + port + '/' +
+                        [endpoint, version, resource_type, resource_name].join('/')
+
+                  url = url + "?" + URI.encode_www_form(query) unless query.empty?
+                  return url
                 end
 
                 def to_uri

--- a/spec/puppetserver/ca/action/list_spec.rb
+++ b/spec/puppetserver/ca/action/list_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
 
   describe 'error handling' do
     it 'logs when no certs are found' do
-      allow(action).to receive(:get_all_certs).and_return([])
+      allow(action).to receive(:get_certs_or_csrs).and_return([])
       exit_code = action.run({})
       expect(exit_code).to eq(0)
       expect(out.string).to include('No certificates to list')
     end
 
     it 'logs requested certs' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({})
       expect(exit_code).to eq(0)
       expect(out.string).to match(/Requested Certificates:.*baz.*\(SHA256\).*two.*alt names:.*"DNS:baz", "DNS:bar".*/m)
@@ -36,7 +36,7 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
     end
 
     it 'logs requested, signed, and revoked certs with --all flag' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'all' => true})
       expect(exit_code).to eq(0)
       expect(out.string).to match(/Requested Certificates:.*baz.*\(SHA256\).*two.*alt names:.*"DNS:baz", "DNS:bar".*authorization extensions: \[pp_cli_auth: true, pp_provisioner: true\].*/m)
@@ -45,7 +45,7 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
     end
 
     it 'logs requested certs with --certs flag' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['foo','baz']})
       expect(exit_code).to eq(0)
       expect(out.string).to match(/Requested Certificates:.*baz.*\(SHA256\).*two.*alt names:.*"DNS:baz", "DNS:bar".*/m)
@@ -54,14 +54,14 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
     end
 
     it 'logs a non-existent cert as missing when requested with --certs flag' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['fake']})
       expect(exit_code).to eq(1)
       expect(out.string).to match(/Missing Certificates:.*fake.*/m)
     end
 
     it 'errors when any requested certs are missing with --certs flag' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['foo','fake']})
       expect(exit_code).to eq(1)
       expect(out.string).to match(/Signed Certificates:.*foo.*\(SHA256\).*three.*alt names:.*"DNS:foo", "DNS:bar".*/m)
@@ -69,13 +69,13 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
     end
 
     it 'errors when unknown format option is passed in' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'test'})
       expect(exit_code).to eq(1)
     end
 
     it 'does not throw error when json format option is passed in' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'json'})
       expect(exit_code).to eq(0)
       parsed_output = JSON.parse(out.string)
@@ -85,14 +85,14 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
     end
 
     it 'does not throw error when text format option is passed in' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'text'})
       expect(exit_code).to eq(0)
       expect(out.string).to match(/Signed Certificates:.*foo.*\(SHA256\).*three.*alt names:.*"DNS:foo", "DNS:bar".*/m)
     end
 
     it 'returns the correct output, including empty keys with the --all option' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'all' => true, 'format' => 'json'})
       expect(exit_code).to eq(0)
       parsed_output = JSON.parse(out.string)
@@ -103,7 +103,7 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
     end
 
     it 'output the non-existent cert as a JSON object with the missing key' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['pup'], 'format' => 'json'})
       expect(exit_code).to eq(1)
       parsed_output = JSON.parse(out.string)

--- a/spec/puppetserver/ca/utils/http_client_spec.rb
+++ b/spec/puppetserver/ca/utils/http_client_spec.rb
@@ -46,10 +46,18 @@ RSpec.describe Puppetserver::Ca::Utils::HttpClient do
     FileUtils.cp(settings[:cacert], settings[:localcacert])
     FileUtils.cp(settings[:cacrl], settings[:hostcrl])
 
-    client = Puppetserver::Ca::Utils::HttpClient.new(logger, settings) 
+    client = Puppetserver::Ca::Utils::HttpClient.new(logger, settings)
     store = client.store
 
     expect(store.verify(hostcert)).to be(true)
     expect(store.verify(cacert)).to be(true)
+  end
+
+  it 'create a URL with query params correctly' do
+    query = { :state => "requested" }
+    url = Puppetserver::Ca::Utils::HttpClient::URL.new('https', 'localhost', '8140',
+                                                       'puppet-ca', 'v1', 'certificate_statuses', 'any_key', query)
+    result = url.to_uri
+    expect(result.to_s).to eq("https://localhost:8140/puppet-ca/v1/certificate_statuses/any_key?state=requested")
   end
 end


### PR DESCRIPTION
This commits modified the `puppetserver ca list` command to only walk the directory of certificate requests when the user
want to get certificate requests. This should improve the speed when running the command `puppetserver ca list` without any option flags.