### PR TITLE
Merge branch 1.x

### DIFF
--- a/lib/puppetserver/ca/certificate_authority.rb
+++ b/lib/puppetserver/ca/certificate_authority.rb
@@ -41,8 +41,8 @@ module Puppetserver
       end
 
       # Returns a URI-like wrapper around CA specific urls
-      def make_ca_url(resource_type = nil, certname = nil)
-        HttpClient::URL.new('https', @ca_server, @ca_port, 'puppet-ca', 'v1', resource_type, certname)
+      def make_ca_url(resource_type = nil, certname = nil, query = {})
+        HttpClient::URL.new('https', @ca_server, @ca_port, 'puppet-ca', 'v1', resource_type, certname, query)
       end
 
       def process_ttl_input(ttl)
@@ -141,7 +141,7 @@ module Puppetserver
         when :revoke
           case result.code
           when '200', '204'
-            @logger.inform "Revoked certificate for #{certname}"
+            @logger.inform "Certificate for #{certname} has been revoked"
             return :success
           when '404'
             @logger.err 'Error:'
@@ -215,7 +215,7 @@ module Puppetserver
       def check_revocation(certname, result)
         case result.code
         when '200', '204'
-          @logger.inform "Revoked certificate for #{certname}"
+          @logger.inform "Certificate for #{certname} has been revoked"
           return :success
         when '409'
           return :invalid
@@ -250,8 +250,8 @@ module Puppetserver
       end
 
       # Returns nil for errors, else the result of the GET request
-      def get_certificate_statuses
-        result = get('certificate_statuses', 'any_key')
+      def get_certificate_statuses(query = {})
+        result = get('certificate_statuses', 'any_key', query)
 
         unless result.code == '200'
           @logger.err 'Error:'
@@ -287,8 +287,8 @@ module Puppetserver
       # @param resource_type [String] the resource type of url
       # @param resource_name [String] the resource name of url
       # @return [Struct] an instance of the Result struct with :code, :body
-      def get(resource_type, resource_name)
-        url = make_ca_url(resource_type, resource_name)
+      def get(resource_type, resource_name, query = {})
+        url = make_ca_url(resource_type, resource_name, query)
         @client.with_connection(url) do |connection|
           connection.get(url)
         end

--- a/lib/puppetserver/ca/utils/http_client.rb
+++ b/lib/puppetserver/ca/utils/http_client.rb
@@ -1,5 +1,6 @@
 require 'net/https'
 require 'openssl'
+require 'uri'
 
 require 'puppetserver/ca/errors'
 
@@ -114,7 +115,6 @@ module Puppetserver
             request.body = body
             result = @conn.request(request)
 
-
             Result.new(result.code, result.body)
           end
 
@@ -136,10 +136,13 @@ module Puppetserver
         # Like URI, but not... maybe of suspicious value
         URL = Struct.new(:protocol, :host, :port,
                          :endpoint, :version,
-                         :resource_type, :resource_name) do
+                         :resource_type, :resource_name, :query) do
                 def full_url
-                  protocol + '://' + host + ':' + port + '/' +
-                  [endpoint, version, resource_type, resource_name].join('/')
+                  url = protocol + '://' + host + ':' + port + '/' +
+                        [endpoint, version, resource_type, resource_name].join('/')
+
+                  url = url + "?" + URI.encode_www_form(query) unless query.empty?
+                  return url
                 end
 
                 def to_uri

--- a/spec/puppetserver/ca/action/clean_spec.rb
+++ b/spec/puppetserver/ca/action/clean_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Puppetserver::Ca::Action::Clean do
 
       code = subject.run({'certnames' => ['foo']})
       expect(code).to eq(0)
-      expect(stdout.string).to match(/Revoked.*foo/)
+      expect(stdout.string).to match(/Certificate.*foo/)
       expect(stdout.string).to include('Cleaned files related to foo')
       expect(Utils::Helpers.remove_cadir_deprecation(stderr)).to be_empty
     end

--- a/spec/puppetserver/ca/action/list_spec.rb
+++ b/spec/puppetserver/ca/action/list_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
 
   describe 'error handling' do
     it 'logs when no certs are found' do
-      allow(action).to receive(:get_all_certs).and_return([])
+      allow(action).to receive(:get_certs_or_csrs).and_return([])
       exit_code = action.run({})
       expect(exit_code).to eq(0)
       expect(out.string).to include('No certificates to list')
     end
 
     it 'logs requested certs' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({})
       expect(exit_code).to eq(0)
       expect(out.string).to match(/Requested Certificates:.*baz.*\(SHA256\).*two.*alt names:.*"DNS:baz", "DNS:bar".*/m)
@@ -36,7 +36,7 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
     end
 
     it 'logs requested, signed, and revoked certs with --all flag' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'all' => true})
       expect(exit_code).to eq(0)
       expect(out.string).to match(/Requested Certificates:.*baz.*\(SHA256\).*two.*alt names:.*"DNS:baz", "DNS:bar".*authorization extensions: \[pp_cli_auth: true, pp_provisioner: true\].*/m)
@@ -45,7 +45,7 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
     end
 
     it 'logs requested certs with --certs flag' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['foo','baz']})
       expect(exit_code).to eq(0)
       expect(out.string).to match(/Requested Certificates:.*baz.*\(SHA256\).*two.*alt names:.*"DNS:baz", "DNS:bar".*/m)
@@ -54,14 +54,14 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
     end
 
     it 'logs a non-existent cert as missing when requested with --certs flag' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['fake']})
       expect(exit_code).to eq(1)
       expect(out.string).to match(/Missing Certificates:.*fake.*/m)
     end
 
     it 'errors when any requested certs are missing with --certs flag' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['foo','fake']})
       expect(exit_code).to eq(1)
       expect(out.string).to match(/Signed Certificates:.*foo.*\(SHA256\).*three.*alt names:.*"DNS:foo", "DNS:bar".*/m)
@@ -69,13 +69,13 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
     end
 
     it 'errors when unknown format option is passed in' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'test'})
       expect(exit_code).to eq(1)
     end
 
     it 'does not throw error when json format option is passed in' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'json'})
       expect(exit_code).to eq(0)
       parsed_output = JSON.parse(out.string)
@@ -85,14 +85,14 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
     end
 
     it 'does not throw error when text format option is passed in' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['foo', 'baz'], 'format' => 'text'})
       expect(exit_code).to eq(0)
       expect(out.string).to match(/Signed Certificates:.*foo.*\(SHA256\).*three.*alt names:.*"DNS:foo", "DNS:bar".*/m)
     end
 
     it 'returns the correct output, including empty keys with the --all option' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'all' => true, 'format' => 'json'})
       expect(exit_code).to eq(0)
       parsed_output = JSON.parse(out.string)
@@ -103,7 +103,7 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
     end
 
     it 'output the non-existent cert as a JSON object with the missing key' do
-      allow(action).to receive(:get_all_certs).and_return(result)
+      allow(action).to receive(:get_certs_or_csrs).and_return(result)
       exit_code = action.run({'certname' => ['pup'], 'format' => 'json'})
       expect(exit_code).to eq(1)
       parsed_output = JSON.parse(out.string)

--- a/spec/puppetserver/ca/action/revoke_spec.rb
+++ b/spec/puppetserver/ca/action/revoke_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Puppetserver::Ca::Action::Revoke do
 
       code = subject.run({'certnames' => ['foo']})
       expect(code).to eq(0)
-      expect(stdout.string.chomp).to eq('Revoked certificate for foo')
+      expect(stdout.string.chomp).to eq('Certificate for foo has been revoked')
       expect(Utils::Helpers.remove_cadir_deprecation(stderr)).to be_empty
     end
 
@@ -79,7 +79,7 @@ RSpec.describe Puppetserver::Ca::Action::Revoke do
 
       code = subject.run({'certnames' => ['foo', 'bar']})
       expect(code).to eq(1)
-      expect(stdout.string.chomp).to eq('Revoked certificate for bar')
+      expect(stdout.string.chomp).to eq('Certificate for bar has been revoked')
       expect(stderr.string).to match(/Error.*not find certificate for foo/m)
     end
 
@@ -89,7 +89,7 @@ RSpec.describe Puppetserver::Ca::Action::Revoke do
 
       code = subject.run({'certnames' => ['foo', 'bar']})
       expect(code).to eq(24)
-      expect(stdout.string.chomp).to eq('Revoked certificate for bar')
+      expect(stdout.string.chomp).to eq('Certificate for bar has been revoked')
       expect(stderr.string).to match(/Error.*not revoke unsigned csr for foo/m)
     end
 
@@ -100,7 +100,7 @@ RSpec.describe Puppetserver::Ca::Action::Revoke do
 
       code = subject.run({'certnames' => ['foo', 'bar', 'baz']})
       expect(code).to eq(1)
-      expect(stdout.string.chomp).to eq('Revoked certificate for bar')
+      expect(stdout.string.chomp).to eq('Certificate for bar has been revoked')
       expect(stderr.string).to match(/Error.*not revoke unsigned csr for baz/m)
       expect(stderr.string).to match(/Error.*not find certificate for foo/m)
     end
@@ -111,7 +111,7 @@ RSpec.describe Puppetserver::Ca::Action::Revoke do
 
       code = subject.run({'certnames' => ['foo', 'bar']})
       expect(code).to eq(1)
-      expect(stdout.string.chomp).to eq('Revoked certificate for bar')
+      expect(stdout.string.chomp).to eq('Certificate for bar has been revoked')
       expect(stderr.string).
         to match(/Error.*attempting to revoke.*code: 500.*body: Internal Server Error/m)
     end

--- a/spec/puppetserver/ca/utils/http_client_spec.rb
+++ b/spec/puppetserver/ca/utils/http_client_spec.rb
@@ -48,4 +48,12 @@ RSpec.describe Puppetserver::Ca::Utils::HttpClient do
       expect(store.verify(cacert)).to be(true)
     end
   end
+
+  it 'create a URL with query params correctly' do
+    query = { :state => "requested" }
+    url = Puppetserver::Ca::Utils::HttpClient::URL.new('https', 'localhost', '8140',
+                                                       'puppet-ca', 'v1', 'certificate_statuses', 'any_key', query)
+    result = url.to_uri
+    expect(result.to_s).to eq("https://localhost:8140/puppet-ca/v1/certificate_statuses/any_key?state=requested")
+  end
 end


### PR DESCRIPTION
What this merge contains:
- Update the revoke message out when revoking a certificate to be more assuring to users
- Improve the speed of `puppetserver-ca list` when querying for CSR by using the updated certificate_statuses endpoint.