### PR TITLE
Merge 1.x branch

### DIFF
--- a/lib/puppetserver/ca/action/prune.rb
+++ b/lib/puppetserver/ca/action/prune.rb
@@ -31,6 +31,7 @@ BANNER
 
         def run(inputs)
           config_path = inputs['config']
+          exit_code = 0
 
           # Validate the config path.
           if config_path
@@ -49,55 +50,59 @@ BANNER
           # Getting the CRL(s)
           loader = X509Loader.new(puppet.settings[:cacert], puppet.settings[:cakey], puppet.settings[:cacrl])
 
-          puppet_crl = loader.crls.select { |crl| crl.verify(loader.key) }
-          number_of_removed_duplicates = prune_CRLs(puppet_crl)
+          verified_crls = loader.crls.select { |crl| crl.verify(loader.key) }
 
-          if number_of_removed_duplicates > 0
-            update_pruned_CRL(puppet_crl, loader.key)
-            FileSystem.write_file(puppet.settings[:cacrl], loader.crls, 0644)
-            @logger.inform("Removed #{number_of_removed_duplicates} duplicated certs from Puppet's CRL.")
+          if verified_crls.length == 1
+            puppet_crl = verified_crls.first
+            @logger.inform("Total number of certificates found in Puppet's CRL is: #{puppet_crl.revoked.length}.")
+            number_of_removed_duplicates = prune_CRL(puppet_crl)
+
+            if number_of_removed_duplicates > 0
+              update_pruned_CRL(puppet_crl, loader.key)
+              FileSystem.write_file(puppet.settings[:cacrl], loader.crls, 0644)
+              @logger.inform("Removed #{number_of_removed_duplicates} duplicated certs from Puppet's CRL.")
+            else
+              @logger.inform("No duplicate revocations found in the CRL.")
+            end
           else
-            @logger.inform("No duplicate revocations found in the CRL.")
+            @logger.err("Could not identify Puppet's CRL. Aborting prune action.")
+            exit_code = 1
           end
 
-          return 0
+          return exit_code
         end
 
-        def prune_CRLs(crl_list)
+        def prune_CRL(crl)
           number_of_removed_duplicates = 0
 
-          crl_list.each do |crl|
-            existed_serial_number = Set.new()
-            revoked_list = crl.revoked
-            @logger.debug("Pruning duplicate entries in CRL for issuer " \
-              "#{crl.issuer.to_s(OpenSSL::X509::Name::RFC2253)}") if @logger.debug?
+          existed_serial_number = Set.new()
+          revoked_list = crl.revoked
+          @logger.debug("Pruning duplicate entries in CRL for issuer " \
+            "#{crl.issuer.to_s(OpenSSL::X509::Name::RFC2253)}") if @logger.debug?
 
-            revoked_list.delete_if do |revoked|
-              if existed_serial_number.add?(revoked.serial)
-                false
-              else
-                number_of_removed_duplicates += 1
-                @logger.debug("Removing duplicate of #{revoked.serial}, " \
-                  "revoked on #{revoked.time}\n") if @logger.debug?
-                true
-              end
+          revoked_list.delete_if do |revoked|
+            if existed_serial_number.add?(revoked.serial)
+              false
+            else
+              number_of_removed_duplicates += 1
+              @logger.debug("Removing duplicate of #{revoked.serial}, " \
+                "revoked on #{revoked.time}\n") if @logger.debug?
+              true
             end
-            crl.revoked=(revoked_list)
           end
+          crl.revoked=(revoked_list)
 
           return number_of_removed_duplicates
         end
 
-        def update_pruned_CRL(crl_list, pkey)
-          crl_list.each do |crl|
-            number_ext, other_ext = crl.extensions.partition{ |ext| ext.oid == "crlNumber" }
-            number_ext.each do |crl_number|
-              updated_crl_number = OpenSSL::BN.new(crl_number.value) + OpenSSL::BN.new(1)
-              crl_number.value=(OpenSSL::ASN1::Integer(updated_crl_number))
-            end
-            crl.extensions=(number_ext + other_ext)
-            crl.sign(pkey, OpenSSL::Digest::SHA256.new)
+        def update_pruned_CRL(crl, pkey)
+          number_ext, other_ext = crl.extensions.partition{ |ext| ext.oid == "crlNumber" }
+          number_ext.each do |crl_number|
+            updated_crl_number = OpenSSL::BN.new(crl_number.value) + OpenSSL::BN.new(1)
+            crl_number.value=(OpenSSL::ASN1::Integer(updated_crl_number))
           end
+          crl.extensions=(number_ext + other_ext)
+          crl.sign(pkey, OpenSSL::Digest::SHA256.new)
         end
 
         def self.parser(parsed = {})

--- a/lib/puppetserver/ca/utils/http_client.rb
+++ b/lib/puppetserver/ca/utils/http_client.rb
@@ -141,7 +141,7 @@ module Puppetserver
                   url = protocol + '://' + host + ':' + port + '/' +
                         [endpoint, version, resource_type, resource_name].join('/')
 
-                  url = url + "?" + URI.encode_www_form(query) unless query.empty?
+                  url = url + "?" + URI.encode_www_form(query) unless query.nil? || query.empty?
                   return url
                 end
 

--- a/spec/puppetserver/ca/action/prune_spec.rb
+++ b/spec/puppetserver/ca/action/prune_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Puppetserver::Ca::Action::Prune do
       revoked_cert = create_cert(ca_key, 'revoked')
       ca_crl = create_crl(ca_cert, ca_key, Array.new(5, revoked_cert))
 
-      number_of_removed_duplicates = subject.prune_CRLs([ca_crl])
+      number_of_removed_duplicates = subject.prune_CRL(ca_crl)
       expect(ca_crl.revoked.length).to eq(1)
       expect(number_of_removed_duplicates).to eq(4)
     end
@@ -90,7 +90,7 @@ RSpec.describe Puppetserver::Ca::Action::Prune do
 
       ca_crl = create_crl(ca_cert, ca_key, first_cert + second_cert + third_cert)
 
-      number_of_removed_duplicates = subject.prune_CRLs([ca_crl])
+      number_of_removed_duplicates = subject.prune_CRL(ca_crl)
       expect(ca_crl.revoked.length).to eq(3)
       expect(number_of_removed_duplicates).to eq(15)
     end
@@ -102,11 +102,16 @@ RSpec.describe Puppetserver::Ca::Action::Prune do
       ca_cert = create_cert(ca_key, "Bazzup")
       ca_crl = create_crl(ca_cert, ca_key)
 
-      subject.update_pruned_CRL([ca_crl], ca_key)
+      extensions_before = ca_crl.extensions.select { |ext| ext.oid == "crlNumber"}
+      extensions_before.each do |ext|
+        expect(ext.value.to_i).to eq(0)
+      end
 
-      extensions = ca_crl.extensions.select { |ext| ext.oid == "crlNumber"}
-      extensions.each do |ext|
-        expect(ext.value).to eq("1")
+      subject.update_pruned_CRL(ca_crl, ca_key)
+
+      extensions_after = ca_crl.extensions.select { |ext| ext.oid == "crlNumber"}
+      extensions_after.each do |ext|
+        expect(ext.value.to_i).to eq(1)
       end
     end
   end


### PR DESCRIPTION
This merge contains:
- Update to `prune` action to specifically prune only Puppet's CA CRL and output message of total certificates found before pruning.
- Fix a bug when not checking for `:query` params to be `nil` when creating a URL.