### PR TITLE
(maint) Bug fix to require `set` module in prune

### DIFF
--- a/lib/puppetserver/ca/action/prune.rb
+++ b/lib/puppetserver/ca/action/prune.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 require 'openssl'
+require 'set'
 require 'puppetserver/ca/errors'
 require 'puppetserver/ca/utils/cli_parsing'
 require 'puppetserver/ca/utils/file_system'


### PR DESCRIPTION
This commit fixes a bug that exists for Ruby version 2.5 where the module `Set` is not automatically in scope but needs to be
required.