### PR TITLE
(SERVER-2842) Ensures `generate --ca-client` success when puppetserve…

### DIFF
--- a/spec/puppetserver/ca/action/generate_spec.rb
+++ b/spec/puppetserver/ca/action/generate_spec.rb
@@ -499,4 +499,43 @@ RSpec.describe Puppetserver::Ca::Action::Generate do
       end
     end
   end
+
+  describe "force flag" do
+    it 'errors when generate offline without --force flag when error is not CONNREFUSED' do
+
+      Dir.mktmpdir do |tmpdir|
+        with_temp_dirs tmpdir do |config|
+          allow(subject).to receive(:generate_authorized_certs) { true }
+          allow(httpclient).to receive(:check_server_online).and_raise(
+            Puppetserver::Ca::ConnectionFailed.create(
+              StandardError.new,
+                'UnknownException'))
+
+          expect { subject.run({'certname' => ['foo'],
+                              'config' => config,
+                              'subject-alt-names' => '',
+                              'ca-client' => true})}.to raise_error(Puppetserver::Ca::ConnectionFailed)
+        end
+      end
+    end
+
+    it 'signs when generate offline whilst there is a ConnectionFailed error' do
+      Dir.mktmpdir do |tmpdir|
+        with_temp_dirs tmpdir do |config|
+          allow(subject).to receive(:generate_authorized_certs) { true }
+          allow(httpclient).to receive(:check_server_online).and_raise(
+            Puppetserver::Ca::ConnectionFailed.create(
+             StandardError.new,
+                'UnknownException'))
+
+          expect { subject.run({'certname' => ['foo'],
+                                'config' => config,
+                                'subject-alt-names' => '',
+                                'ca-client' => true,
+                                'force' => true})}.not_to raise_error
+          expect(stdout.string).to include("Continuing with certificate signing")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
…r is offline

This commits ensures that `puppetserver ca generate --ca-client` will not fail due to an error being raised by adding a `--force` flag that suppress the error. The new `--force` flag is meant to be only used with `--ca-client`.