### PR TITLE
Add failure exit code to puppetserver ca list, SERVER-2797

### DIFF
--- a/lib/puppetserver/ca/action/list.rb
+++ b/lib/puppetserver/ca/action/list.rb
@@ -92,7 +92,7 @@ Options:
             found_certs = get_certs_or_csrs(puppet.settings)
             if found_certs.nil?
                # nil is different from no certs found
-               @logger.inform('Error while getting certificates')
+               @logger.err('Error while getting certificates')
                return 1
             end
             all_certs = found_certs.select { |cert| filter_names.call(cert) }
@@ -103,7 +103,7 @@ Options:
             all_csrs = get_certs_or_csrs(puppet.settings, "requested")
             if all_csrs.nil?
                # nil is different from no certs found
-               @logger.inform('Error while getting certificates')
+               @logger.err('Error while getting certificate requests')
                return 1
             end
             output_certs_by_state(all, output_format, all_csrs)
@@ -225,15 +225,10 @@ Options:
           query = queried_state ? { :state => queried_state } : {}
           result = Puppetserver::Ca::CertificateAuthority.new(@logger, settings).get_certificate_statuses(query)
 
-          if result.nil?
-            # nil returned from an errored lookup
-            return nil
-          elsif result
-            # values from a legit lookup
+          if result
             return JSON.parse(result.body)
           else
-            # empty result from a legit lookup
-            return []
+            return nil
           end
         end
 

--- a/spec/puppetserver/ca/action/list_spec.rb
+++ b/spec/puppetserver/ca/action/list_spec.rb
@@ -23,14 +23,14 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
       allow(action).to receive(:get_certs_or_csrs).and_return(nil)
       exit_code = action.run({'all' => true})
       expect(exit_code).to eq(1)
-      expect(out.string).to include('Error while getting certificates')
+      expect(err.string).to include('Error while getting certificates')
     end
 
     it 'exit-1 when run on a non-CA, certnames' do
       allow(action).to receive(:get_certs_or_csrs).and_return(nil)
       exit_code = action.run({'certname' => ['foo','baz']})
       expect(exit_code).to eq(1)
-      expect(out.string).to include('Error while getting certificates')
+      expect(err.string).to include('Error while getting certificates')
     end
 
     it 'logs when no certs are found' do

--- a/spec/puppetserver/ca/action/list_spec.rb
+++ b/spec/puppetserver/ca/action/list_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
       expect(err.string).to include('Error while getting certificates')
     end
 
+    it 'exit-1 when run on a non-CA, no inputs' do
+      allow(action).to receive(:get_certs_or_csrs).and_return(nil)
+      exit_code = action.run({})
+      expect(exit_code).to eq(1)
+      expect(err.string).to include('Error while getting certificate requests')
+    end
+
     it 'logs when no certs are found' do
       allow(action).to receive(:get_certs_or_csrs).and_return([])
       exit_code = action.run({})

--- a/spec/puppetserver/ca/action/list_spec.rb
+++ b/spec/puppetserver/ca/action/list_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
                   "fingerprint"=>"onetwo", "fingerprints"=>{"SHA1"=>"one", "SHA256"=>"onetwo", "SHA512"=>"three", "default"=>"four"}}]}
 
   describe 'error handling' do
+    it 'exit-1 when run on a non-CA, all' do
+      allow(action).to receive(:get_certs_or_csrs).and_return(nil)
+      exit_code = action.run({'all' => true})
+      expect(exit_code).to eq(1)
+      expect(out.string).to include('Error while getting certificates')
+    end
+
+    it 'exit-1 when run on a non-CA, certnames' do
+      allow(action).to receive(:get_certs_or_csrs).and_return(nil)
+      exit_code = action.run({'certname' => ['foo','baz']})
+      expect(exit_code).to eq(1)
+      expect(out.string).to include('Error while getting certificates')
+    end
+
     it 'logs when no certs are found' do
       allow(action).to receive(:get_certs_or_csrs).and_return([])
       exit_code = action.run({})


### PR DESCRIPTION
(SERVER-2797) Add failure exit code when `puppetserver ca list` hits errors.

When running a `puppetserver ca` command on a non-CA server, the command exits with a 0 = ok, when the command has obviously failed.  The failure is easily detected by a human, but less so for a computer.

This seeks to distinguish "failed at looking up" from "found no certificates" and exit accordingly.