### PR TITLE
(SERVER-2797) Add failure exit code when `puppetserver ca list` hits errors.

### DIFF
--- a/lib/puppetserver/ca/action/list.rb
+++ b/lib/puppetserver/ca/action/list.rb
@@ -89,12 +89,23 @@ Options:
           end
 
           if (all || certnames.any?)
-            all_certs = get_certs_or_csrs(puppet.settings).select { |cert| filter_names.call(cert) }
+            found_certs = get_certs_or_csrs(puppet.settings)
+            if found_certs.nil?
+               # nil is different from no certs found
+               @logger.err('Error while getting certificates')
+               return 1
+            end
+            all_certs = found_certs.select { |cert| filter_names.call(cert) }
             requested, signed, revoked = separate_certs(all_certs)
             missing = certnames - all_certs.map { |cert| cert['name'] }
             output_certs_by_state(all, output_format, requested, signed, revoked, missing)
           else
             all_csrs = get_certs_or_csrs(puppet.settings, "requested")
+            if all_csrs.nil?
+               # nil is different from no certs found
+               @logger.err('Error while getting certificate requests')
+               return 1
+            end
             output_certs_by_state(all, output_format, all_csrs)
           end
 
@@ -217,7 +228,7 @@ Options:
           if result
             return JSON.parse(result.body)
           else
-            return []
+            return nil
           end
         end
 

--- a/spec/puppetserver/ca/action/list_spec.rb
+++ b/spec/puppetserver/ca/action/list_spec.rb
@@ -19,6 +19,27 @@ RSpec.describe 'Puppetserver::Ca::Action::List' do
                   "fingerprint"=>"onetwo", "fingerprints"=>{"SHA1"=>"one", "SHA256"=>"onetwo", "SHA512"=>"three", "default"=>"four"}}]}
 
   describe 'error handling' do
+    it 'exit-1 when run on a non-CA, all' do
+      allow(action).to receive(:get_certs_or_csrs).and_return(nil)
+      exit_code = action.run({'all' => true})
+      expect(exit_code).to eq(1)
+      expect(err.string).to include('Error while getting certificates')
+    end
+
+    it 'exit-1 when run on a non-CA, certnames' do
+      allow(action).to receive(:get_certs_or_csrs).and_return(nil)
+      exit_code = action.run({'certname' => ['foo','baz']})
+      expect(exit_code).to eq(1)
+      expect(err.string).to include('Error while getting certificates')
+    end
+
+    it 'exit-1 when run on a non-CA, no inputs' do
+      allow(action).to receive(:get_certs_or_csrs).and_return(nil)
+      exit_code = action.run({})
+      expect(exit_code).to eq(1)
+      expect(err.string).to include('Error while getting certificate requests')
+    end
+
     it 'logs when no certs are found' do
       allow(action).to receive(:get_certs_or_csrs).and_return([])
       exit_code = action.run({})


### PR DESCRIPTION
When running a puppetserver ca command on a non-CA server, the command exits with a 0 = ok, when the command has obviously failed. The failure is easily detected by a human, but less so for a computer.

This seeks to distinguish "failed at looking up" from "found no certificates" and exit accordingly.