### PR TITLE
 PE-35371 Update prune command

### DIFF
--- a/lib/puppetserver/ca/action/prune.rb
+++ b/lib/puppetserver/ca/action/prune.rb
@@ -13,15 +13,20 @@ module Puppetserver
       class Prune
         include Puppetserver::Ca::Utils
 
-        SUMMARY = "Prune the local CRL on disk to remove any duplicated certificates"
+        SUMMARY = "Prune the local CRL on disk to remove certificate entries"
         BANNER = <<-BANNER
 Usage:
   puppetserver ca prune [--help]
   puppetserver ca prune [--config]
+  puppetserver ca prune [--config] [--remove-duplicates]
+  puppetserver ca prune [--config] [--remove-entries] [--serial NUMBER[,NUMBER]] [--certname NAME[,NAME]]
 
 Description:
-  Prune the list of revoked certificates of any duplication within it.  This command
-  will only prune the CRL issued by Puppet's CA cert.
+  Prune the list of revoked certificates. If no options are provided or
+  --remove-duplicates is specified, prune CRL of any duplicate entries.
+  If --remove-entries is specified, remove matching entries provided by
+  --serial and/or --certname values. This command will only prune the CRL
+  issued by Puppet's CA cert.
 
 Options:
 BANNER
@@ -32,6 +37,10 @@ BANNER
 
         def run(inputs)
           config_path = inputs['config']
+          remove_duplicates = inputs['remove-duplicates']
+          remove_entries = inputs['remove-entries']
+          serialnumbers = inputs['serial']
+          certnames = inputs['certname']
           exit_code = 0
 
           # Validate the config path.
@@ -45,31 +54,51 @@ BANNER
           puppet.load(logger: @logger)
           return 1 if Errors.handle_with_usage(@logger, puppet.errors)
 
+          # Validate arguments
+          if (remove_entries && (!serialnumbers && !certnames))
+            return 1 if Errors.handle_with_usage(@logger,["--remove-entries option require --serial or --certname values"])
+          end
+
           # Validate that we are offline
           return 1 if HttpClient.check_server_online(puppet.settings, @logger)
 
           # Getting the CRL(s)
           loader = X509Loader.new(puppet.settings[:cacert], puppet.settings[:cakey], puppet.settings[:cacrl])
+          inventory_file = puppet.settings[:cert_inventory]
+          cadir = puppet.settings[:cadir]
 
           verified_crls = loader.crls.select { |crl| crl.verify(loader.key) }
+          number_of_removed_duplicates = 0
+          number_of_removed_crl_entries = 0
 
           if verified_crls.length == 1
             puppet_crl = verified_crls.first
             @logger.inform("Total number of certificates found in Puppet's CRL is: #{puppet_crl.revoked.length}.")
-            number_of_removed_duplicates = prune_CRL(puppet_crl)
 
-            if number_of_removed_duplicates > 0
+            if remove_entries
+              if serialnumbers
+                number_of_removed_crl_entries += prune_using_serial(puppet_crl, loader.key, serialnumbers)
+              end
+              if certnames
+                number_of_removed_crl_entries += prune_using_certname(puppet_crl, loader.key, inventory_file, cadir, certnames)
+              end
+            end
+            if (remove_duplicates || (!remove_entries))
+               number_of_removed_duplicates += prune_CRL(puppet_crl)
+            end
+
+            if (number_of_removed_duplicates > 0 || number_of_removed_crl_entries > 0)
               update_pruned_CRL(puppet_crl, loader.key)
               FileSystem.write_file(puppet.settings[:cacrl], loader.crls, 0644)
-              @logger.inform("Removed #{number_of_removed_duplicates} duplicated certs from Puppet's CRL.")
+              @logger.inform("Removed #{number_of_removed_duplicates} duplicated certs from Puppet's CRL.") if number_of_removed_duplicates > 0
+              @logger.inform("Removed #{number_of_removed_crl_entries} certs from Puppet's CRL.") if number_of_removed_crl_entries > 0
             else
-              @logger.inform("No duplicate revocations found in the CRL.")
+              @logger.inform("No matching revocations found in the CRL for pruning")
             end
           else
             @logger.err("Could not identify Puppet's CRL. Aborting prune action.")
             exit_code = 1
           end
-
           return exit_code
         end
 
@@ -106,6 +135,57 @@ BANNER
           crl.sign(pkey, OpenSSL::Digest::SHA256.new)
         end
 
+        def prune_using_serial(crl, key, serialnumbers)
+          removed_serials = []
+          revoked_list = crl.revoked
+          @logger.debug("Removing entries in CRL for issuer " \
+            "#{crl.issuer.to_s(OpenSSL::X509::Name::RFC2253)}") if @logger.debug?
+          serialnumbers.each do |serial|
+            if serial.match(/^(?:0[xX])?[A-Fa-f0-9]+$/)
+              revoked_list.delete_if do |revoked|
+                if revoked.serial == OpenSSL::BN.new(serial.hex)
+                  removed_serials.push(serial)
+                  true
+                end
+              end
+            end
+          end
+          crl.revoked = (revoked_list)
+          @logger.debug("Removed these CRL entries : #{removed_serials}") if @logger.debug?
+          return removed_serials.length
+        end
+
+        def prune_using_certname(crl, key, inventory_file, cadir, certnames)
+          serialnumbers = []
+          @logger.debug("Checking inventory file #{inventory_file} for matching cert names") if @logger.debug?
+          errors = FileSystem.validate_file_paths(inventory_file)
+          if errors.empty?
+            File.open(inventory_file).each_line do |line|
+              certnames.each do |certname|
+                if line.match(/\/CN=#{certname}$/) && line.split.length == 4
+                  serialnumbers.push(line.split.first)
+                  certnames.delete(certname)
+                end
+              end
+            end
+          else
+            @logger.inform "Reading inventory file at #{inventory_file} failed with error #{errors}"
+          end
+          if certnames
+            @logger.debug("Checking CA dir #{cadir} for matching cert names")
+            certnames.each do |certname|
+              cert_file = "#{cadir}/signed/#{certname}.pem"
+              if File.file?(cert_file)
+                raw = File.read(cert_file)
+                certificate = OpenSSL::X509::Certificate.new(raw)
+                serial = certificate.serial
+                serialnumbers.push(serial.to_s(16))
+              end
+            end
+            prune_using_serial(crl, key, serialnumbers)
+          end
+        end
+
         def self.parser(parsed = {})
           OptionParser.new do |opts|
             opts.banner = BANNER
@@ -114,6 +194,18 @@ BANNER
             end
             opts.on('--config CONF', 'Path to the puppet.conf file on disk') do |conf|
               parsed['config'] = conf
+            end
+            opts.on('--remove-duplicates', 'Remove duplicate entries from CRL(default)') do |remove_duplicates|
+              parsed['remove-duplicates'] = true
+            end
+            opts.on('--remove-entries', 'Remove entries from CRL') do |remove_entries|
+              parsed['remove-entries'] = true
+            end
+            opts.on('--serial NUMBER[,NUMBER]', Array, 'Serial numbers(s) in HEX to be removed from CRL') do |serialnumbers|
+              parsed['serial'] = serialnumbers
+            end
+            opts.on('--certname NAME[,NAME]', Array, 'Name(s) of the cert(s) to be removed from CRL') do |certnames|
+              parsed['certname'] = certnames
             end
           end
         end

--- a/spec/puppetserver/ca/action/prune_spec.rb
+++ b/spec/puppetserver/ca/action/prune_spec.rb
@@ -16,12 +16,47 @@ RSpec.describe Puppetserver::Ca::Action::Prune do
   let(:logger) { Puppetserver::Ca::Logger.new(:info, stdout, stderr) }
 
   subject { Puppetserver::Ca::Action::Prune.new(logger) }
-
   describe 'flags' do
     it 'take a custom path to the puppet.conf' do
       result, maybe_exit_code = subject.parse(['--config', '/dev/tcp/example.com'])
       expect(maybe_exit_code).to be(nil)
       expect(result['config']).to eq('/dev/tcp/example.com')
+    end
+
+    it 'takes --remove-duplicates option' do
+      result, maybe_code = subject.parse(['--remove-duplicates'])
+      expect(maybe_code).to eq(nil)
+      expect(result['remove-duplicates']).to eq(true)
+    end
+
+    it 'takes --remove-entries option' do
+      result, maybe_code = subject.parse(['--remove-entries'])
+      expect(maybe_code).to eq(nil)
+      expect(result['remove-entries']).to eq(true)
+    end
+
+    it 'takes a single serialnumber' do
+      result, maybe_code = subject.parse(['--serial', '1C'])
+      expect(maybe_code).to eq(nil)
+      expect(result['serial']).to eq(['1C'])
+    end
+
+    it 'takes a comma separated list of serialnumbers' do
+      result, maybe_code = subject.parse(['--serial', '1C,2D'])
+      expect(maybe_code).to eq(nil)
+      expect(result['serial']).to eq(['1C', '2D'])
+    end
+
+    it 'takes a single certname' do
+      result, maybe_code = subject.parse(['--certname', 'foo.example.com'])
+      expect(maybe_code).to eq(nil)
+      expect(result['certname']).to eq(['foo.example.com'])
+    end
+
+    it 'takes a comma separated list of certnames' do
+      result, maybe_code = subject.parse(['--certname', 'foo.example.com,bar'])
+      expect(maybe_code).to eq(nil)
+      expect(result['certname']).to eq(['foo.example.com', 'bar'])
     end
   end
 
@@ -29,6 +64,13 @@ RSpec.describe Puppetserver::Ca::Action::Prune do
     let(:connection) { double }
     let(:online) { Utils::Http::Result.new('200', 'running') }
     let(:offline) { Utils::Http::Result.new('503', 'offline') }
+    let(:tmpdir) { Dir.mktmpdir }
+    let(:settings) {
+      with_ca_in(tmpdir) do |config, confdir|
+        return Puppetserver::Ca::Config::Puppet.new(config).load(cli_overrides: {confdir: confdir }, logger: logger)
+      end
+    }
+    let(:ca) { Puppetserver::Ca::LocalCertificateAuthority.new(OpenSSL::Digest::SHA256.new, settings) }
 
     before do
       allow_any_instance_of(Puppetserver::Ca::Utils::HttpClient).
@@ -37,10 +79,20 @@ RSpec.describe Puppetserver::Ca::Action::Prune do
         to receive(:make_store)
     end
 
+    after(:each) do
+      FileUtils.rm_rf(tmpdir)
+    end
+
     it 'errors when validating path to puppet.conf' do
       exit_code = subject.run({'config' => "fake/faker/puppet.conf"})
       expect(exit_code).to eq(1)
       expect(stderr.string).to eq("Error:\nCould not read file 'fake/faker/puppet.conf'\n")
+    end
+
+    it 'errors when missing argument' do
+      exit_code = subject.run({"remove-entries"=>true})
+      expect(exit_code).to eq(1)
+      expect(stderr.string).to include("Error:\n--remove-entries option require --serial or --certname values")
     end
 
     it 'refuses to prune when server is running' do
@@ -93,6 +145,137 @@ RSpec.describe Puppetserver::Ca::Action::Prune do
       number_of_removed_duplicates = subject.prune_CRL(ca_crl)
       expect(ca_crl.revoked.length).to eq(3)
       expect(number_of_removed_duplicates).to eq(15)
+    end
+
+    it 'reduces a CRL with duplicate revoked certs when called with --remove-duplicates' do
+      allow(connection).to receive(:get).and_return(offline)
+      Dir.mktmpdir do |tmpdir|
+        with_files_in tmpdir do |bundle, key, chain, conf|
+          puppet_conf = File.join(tmpdir, 'puppet.conf')
+          File.open puppet_conf, 'w' do |f|
+            f.puts(<<-INI)
+              [agent]
+                publickeydir = /agent/pubkeys
+              [main]
+                certname = fooberry
+              [master]
+                ssldir = /foo/bar
+                cacrl = #{tmpdir}/ca//crl.pem
+                cadir = #{tmpdir}/ca
+            INI
+          end
+          conf = Puppetserver::Ca::Config::Puppet.new(puppet_conf)
+          conf.load(logger: logger)
+          ca_key = OpenSSL::PKey::RSA.new(512)
+          ca_cert = create_cert(ca_key, "You-Shall-Not-Pass")
+          revoked_cert = create_cert(ca_key, 'revoked')
+          ca_crl = create_crl(ca_cert, ca_key, Array.new(5, revoked_cert))
+          File.write("#{tmpdir}/ca/ca_crt.pem", ca_cert)
+          File.write("#{tmpdir}/ca/ca_key.pem", ca_key)
+          File.write("#{tmpdir}/ca/crl.pem", ca_crl)
+
+          exit_code = subject.run({"config"=>puppet_conf,"remove-duplicates"=>true})
+          updated_crl = OpenSSL::X509::CRL::new(File.read("#{tmpdir}/ca/crl.pem"))
+          expect(exit_code).to eq(0)
+          expect(updated_crl.revoked.length).to eq(1)
+          expect(stdout.string).to include("Removed 4 duplicated certs from Puppet's CRL.")
+        end
+      end
+    end
+
+    it 'removes crl entry when passing single serial number' do
+      allow(connection).to receive(:get).and_return(offline)
+      ca_key = OpenSSL::PKey::RSA.new(512)
+      ca_cert = create_cert(ca_key, "You-Shall-Not-Pass")
+      revoked_cert = create_cert(ca_key, 'foo')
+      ca_crl = create_crl(ca_cert, ca_key, Array.new(1, revoked_cert))
+      number_of_removed_crl_entries = subject.prune_using_serial(ca_crl, ca_key, [revoked_cert.serial.to_s(16)])
+      expect(number_of_removed_crl_entries).to eq(1)
+      expect(ca_crl.revoked.length).to eq(0)
+    end
+
+    it 'remove crl entries when passing multiple  serial numbers' do
+      allow(connection).to receive(:get).and_return(offline)
+      ca_key = OpenSSL::PKey::RSA.new(512)
+      ca_cert = create_cert(ca_key, "You-Shall-Not-Pass")
+      first_revoked_cert = create_cert(ca_key, 'foo')
+      second_revoked_cert = create_cert(ca_key, 'bar')
+      ca_crl = create_crl(ca_cert, ca_key, [first_revoked_cert, second_revoked_cert])
+      number_of_removed_crl_entries = subject.prune_using_serial(ca_crl, ca_key, [first_revoked_cert.serial.to_s(16),second_revoked_cert.serial.to_s(16)])
+      expect(number_of_removed_crl_entries).to eq(2)
+      expect(ca_crl.revoked.length).to eq(0)
+    end
+
+    it 'removes crl entry when passing single certname' do
+      allow(connection).to receive(:get).and_return(offline)
+      ca_key = OpenSSL::PKey::RSA.new(512)
+      ca_cert = create_cert(ca_key, "You-Shall-Not-Pass")
+      revoked_cert = create_cert(ca_key, 'foo')
+      ca_crl = create_crl(ca_cert, ca_key, Array.new(1, revoked_cert))
+      File.write(settings[:cert_inventory], ca.inventory_entry(revoked_cert))
+      allow(File).to receive(:exist?).and_return(true)
+      number_of_removed_crl_entries = subject.prune_using_certname(ca_crl, ca_key, settings[:cert_inventory], settings[:cadir], ["foo"])
+      expect(number_of_removed_crl_entries).to eq(1)
+      expect(ca_crl.revoked.length).to eq(0)
+    end
+
+    it 'removes crl entry when passing multiple certnames' do
+      allow(connection).to receive(:get).and_return(offline)
+      ca_key = OpenSSL::PKey::RSA.new(512)
+      ca_cert = create_cert(ca_key, "You-Shall-Not-Pass")
+      first_revoked_cert = create_cert(ca_key, 'foo')
+      second_revoked_cert = create_cert(ca_key, 'bar')
+      ca_crl = create_crl(ca_cert, ca_key, [first_revoked_cert, second_revoked_cert])
+      inventory_entries = ca.inventory_entry(first_revoked_cert) + "\n" + ca.inventory_entry(second_revoked_cert)
+      File.write(settings[:cert_inventory], inventory_entries)
+      allow(File).to receive(:exist?).and_return(true)
+      number_of_removed_crl_entries = subject.prune_using_certname(ca_crl, ca_key, settings[:cert_inventory], settings[:cadir], ["foo","bar"])
+      expect(number_of_removed_crl_entries).to eq(2)
+      expect(ca_crl.revoked.length).to eq(0)
+    end
+
+    it 'removes crl entry when passing certnames that are not in inventory.txt' do
+      allow(connection).to receive(:get).and_return(offline)
+      ca_key = OpenSSL::PKey::RSA.new(512)
+      ca_cert = create_cert(ca_key, "You-Shall-Not-Pass")
+      first_revoked_cert = create_cert(ca_key, 'foo')
+      second_revoked_cert = create_cert(ca_key, 'bar')
+      ca_crl = create_crl(ca_cert, ca_key, [first_revoked_cert, second_revoked_cert])
+      inventory_entries = ca.inventory_entry(first_revoked_cert)
+      File.write(settings[:cert_inventory], inventory_entries)
+      File.write("#{settings[:cadir]}/signed/bar.pem", second_revoked_cert)
+      allow(File).to receive(:exist?).and_return(true)
+      number_of_removed_crl_entries = subject.prune_using_certname(ca_crl, ca_key, settings[:cert_inventory], settings[:cadir], ["foo","bar"])
+      expect(number_of_removed_crl_entries).to eq(2)
+      expect(ca_crl.revoked.length).to eq(0)
+    end
+
+    it 'prints warning when inventory file is missing and still removes crl entry' do
+      allow(connection).to receive(:get).and_return(offline)
+      ca_key = OpenSSL::PKey::RSA.new(512)
+      ca_cert = create_cert(ca_key, "You-Shall-Not-Pass")
+      revoked_cert = create_cert(ca_key, 'foo')
+      ca_crl = create_crl(ca_cert, ca_key, [revoked_cert])
+      File.write("#{settings[:cadir]}/signed/foo.pem", revoked_cert)
+      allow(File).to receive(:exists?).with(settings[:cert_inventory]).and_return(false)
+      allow(File).to receive(:exists?).with("#{settings[:cadir]}/signed/foo.pem").and_return(true)
+      number_of_removed_crl_entries = subject.prune_using_certname(ca_crl, ca_key, settings[:cert_inventory], settings[:cadir], ["foo"])
+      expect(number_of_removed_crl_entries).to eq(1)
+      expect(ca_crl.revoked.length).to eq(0)
+      expect(stdout.string).to include("Reading inventory file at #{settings[:cert_inventory]} failed with error")
+    end
+
+    it 'correctly parse inventory.txt file with miscellaneous entries' do
+      allow(connection).to receive(:get).and_return(offline)
+      ca_key = OpenSSL::PKey::RSA.new(512)
+      ca_cert = create_cert(ca_key, "You-Shall-Not-Pass")
+      revoked_cert = create_cert(ca_key, 'foo.example.com')
+      ca_crl = create_crl(ca_cert, ca_key, Array.new(1, revoked_cert))
+      File.write(settings[:cert_inventory], "\n"+"I am bad foo.example.com\n"+ca.inventory_entry(revoked_cert)+"\nHello")
+      allow(File).to receive(:exist?).and_return(true)
+      number_of_removed_crl_entries = subject.prune_using_certname(ca_crl, ca_key, settings[:cert_inventory], settings[:cadir], ["foo.example.com"])
+      expect(number_of_removed_crl_entries).to eq(1)
+      expect(ca_crl.revoked.length).to eq(0)
     end
   end
 


### PR DESCRIPTION
Update prune command to take serialnumber(s) or certname(s) and remove corresponding entries from CRL. When serial numbers are given, the CRL will be searched for matching entries and will be deleted. If certnames are given, inventory.txt file will be searched for a matching certname, if found the corresponding serial number will be read and deleted from CRL. If the certname is not in inventory.txt, CA dir will be searched for a matching certificate and correspoding serial number will be deleted from CRL.