### PR TITLE
(PE-34952) Add inventory library

### DIFF
--- a/lib/puppetserver/ca/action/prune.rb
+++ b/lib/puppetserver/ca/action/prune.rb
@@ -6,6 +6,7 @@ require 'puppetserver/ca/utils/cli_parsing'
 require 'puppetserver/ca/utils/file_system'
 require 'puppetserver/ca/utils/config'
 require 'puppetserver/ca/x509_loader'
+require 'puppetserver/ca/config/puppet'
 
 module Puppetserver
   module Ca

--- a/lib/puppetserver/ca/utils/inventory.rb
+++ b/lib/puppetserver/ca/utils/inventory.rb
@@ -1,0 +1,84 @@
+require 'time'
+
+module Puppetserver
+  module Ca
+    module Utils
+      module Inventory
+
+        # Note that the inventory file may have multiple entries for the same certname,
+        # so it should only provide the latest cert for the given certname.
+        def self.parse_inventory_file(path, logger)
+          unless File.exist?(path)
+            logger.err("Could not find inventory at #{path}")
+            return [{}, true]
+          end
+          inventory = {}
+          errored = false
+          File.readlines(path).each do |line|
+            # Shouldn't be any blank lines, but skip them if there are
+            next if line.strip.empty?
+            
+            items = line.strip.split
+            if items.count != 4
+              logger.err("Invalid entry found in inventory.txt: #{line}")
+              errored = true
+              next
+            end
+            unless items[0].match(/^(?:0x)?[A-Fa-f0-9]+$/)
+              logger.err("Invalid serial found in inventory.txt line: #{line}")
+              errored = true
+              next
+            end
+            serial = items[0].hex
+            not_before = nil
+            not_after = nil
+            begin
+              not_before = Time.parse(items[1])
+            rescue ArgumentError
+              logger.err("Invalid not_before time found in inventory.txt line: #{line}")
+              errored = true
+              next
+            end
+            begin
+              not_after = Time.parse(items[2])
+            rescue ArgumentError
+              logger.err("Invalid not_after time found in inventory.txt line: #{line}")
+              errored = true
+              next
+            end
+            unless items[3].start_with?('/CN=')
+              logger.err("Invalid certname found in inventory.txt line: #{line}")
+              errored = true
+              next
+            end
+            certname = items[3][4..-1]
+
+            if !inventory.keys.include?(certname) 
+              inventory[certname] = {
+                :serial => serial,
+                :old_serials => [],
+                :not_before => not_before,
+                :not_after => not_after,
+              }
+            else
+              if not_after >= inventory[certname][:not_after]
+                # This is a newer cert than the one we currently have recorded,
+                # so save the previous serial in :old_serials
+                inventory[certname][:old_serials] << inventory[certname][:serial]
+                inventory[certname][:serial] = serial
+                inventory[certname][:not_before] = not_before
+                inventory[certname][:not_after] = not_after
+              else
+                # This somehow is an older cert (shouldn't really be possible as we just append
+                # to the file with each new cert and we are reading it order)
+                inventory[certname][:old_serials] << serial
+              end
+            end
+          end
+          [inventory, errored]
+        end
+      end
+    end
+  end
+end
+

--- a/spec/puppetserver/ca/action/migrate_spec.rb
+++ b/spec/puppetserver/ca/action/migrate_spec.rb
@@ -91,6 +91,8 @@ RSpec.describe Puppetserver::Ca::Action::Migrate do
       expect(File.readlink(old_cadir)).to eq(new_cadir)
       expect(File.exist?(File.join(old_cadir, 'newfile')))
       expect(File.exist?(File.join(new_cadir, 'newfile')))
+      FileUtils.rm_rf(new_cadir.gsub('/ca',''))
+      FileUtils.rm_rf(old_cadir.gsub('/ca',''))
     end
   end
 end

--- a/spec/puppetserver/ca/local_certificate_authority_spec.rb
+++ b/spec/puppetserver/ca/local_certificate_authority_spec.rb
@@ -34,11 +34,13 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
     end
 
     context 'when an ssl asset is missing' do
+      let(:cadir) { Dir.mktmpdir }
       let(:settings) {
-        with_ca_in(Dir.mktmpdir) do |config|
+        with_ca_in(cadir) do |config|
           return Puppetserver::Ca::Config::Puppet.new(config).load(cli_overrides: {cacert: '/some/rando/path'}, logger: logger)
         end
       }
+      after(:each) { FileUtils.rm_rf(cadir) }
       it 'does not load ssl assets if they are not found' do
         expect(subject.cert).to be_nil
         expect(subject.key).to be_nil

--- a/spec/puppetserver/ca/utils/inventory_spec.rb
+++ b/spec/puppetserver/ca/utils/inventory_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+require 'puppetserver/ca/utils/inventory'
+
+RSpec.describe Puppetserver::Ca::Utils::Inventory do
+  def timefmt(time)
+    time.utc.strftime("%Y-%m-%dT%H:%M:%SUTC")
+  end
+
+  def write_inventory(dir, contents)
+    File.write("#{dir}/inventory.txt", contents)
+  end
+
+  describe 'parse_inventory_file' do
+    let(:inventory) { 
+      t = Time.parse("2023-01-11 09:00:00.000000000 +0000")
+      not_before_unexpired = t - 1
+      not_after_unexpired = t + 360000
+      not_before_expired = t - 100
+      not_after_expired = t - 1
+      # Real inventory won't have an extra newline, but putting it here to ensure
+      # it ignores it correctly.
+      <<~INV
+      0x0001 #{timefmt(not_before_expired)} #{timefmt(not_after_expired)} /CN=foo
+      0x0002 #{timefmt(not_before_expired)} #{timefmt(not_after_expired)} /CN=bar
+      0x0003 #{timefmt(not_before_unexpired)} #{timefmt(not_after_unexpired)} /CN=bar
+
+      INV
+    }
+    let(:logger) { double }
+    let(:correct) { 
+      t = Time.parse("2023-01-11 09:00:00.000000000 +0000")
+      {
+        'foo' => {
+          :serial => 1,
+          :not_before => t - 100,
+          :not_after => t - 1,
+          :old_serials => [],
+        },
+        'bar' => {
+          :serial => 3,
+          :not_before => t - 1,
+          :not_after => t + 360000,
+          :old_serials => [2],
+        }
+      }
+    }
+
+    it 'handles when inventory.txt does not exist' do
+      Dir.mktmpdir do |tmpdir|
+        expect(logger).to receive(:err).with("Could not find inventory at #{tmpdir}/inventory.txt")
+        expect(subject.parse_inventory_file("#{tmpdir}/inventory.txt", logger)).to eq([{}, true])
+      end
+    end
+
+    it 'handles an inventory.txt with an invalid line' do
+      Dir.mktmpdir do |tmpdir|
+        write_inventory(tmpdir, inventory)
+        File.write("#{tmpdir}/inventory.txt", "This is a bad inventory line", mode: 'a')
+        expect(logger).to receive(:err).with(/Invalid entry found in inventory.txt/)
+        expect(subject.parse_inventory_file("#{tmpdir}/inventory.txt", logger)).to eq([correct, true])
+      end
+    end
+
+    it 'handles an inventory.txt line with an invalid serial' do 
+      Dir.mktmpdir do |tmpdir|
+        write_inventory(tmpdir, inventory)
+        File.write("#{tmpdir}/inventory.txt", "0xlolwut #{timefmt(Time.now)} #{timefmt(Time.now)} /CN=badnode", mode: 'a')
+        expect(logger).to receive(:err).with(/Invalid serial found in inventory.txt line/)
+        expect(subject.parse_inventory_file("#{tmpdir}/inventory.txt", logger)).to eq([correct, true])
+      end
+    end
+
+    it 'handles an inventory.txt line with an invalid not_before' do 
+      Dir.mktmpdir do |tmpdir|
+        write_inventory(tmpdir, inventory)
+        File.write("#{tmpdir}/inventory.txt", "0x0004 lolwut #{timefmt(Time.now)} /CN=badnode", mode: 'a')
+        expect(logger).to receive(:err).with(/Invalid not_before time found in inventory.txt line/)
+        expect(subject.parse_inventory_file("#{tmpdir}/inventory.txt", logger)).to eq([correct, true])
+      end
+    end
+
+    it 'handles an inventory.txt line with an invalid not_after' do 
+      Dir.mktmpdir do |tmpdir|
+        write_inventory(tmpdir, inventory)
+        File.write("#{tmpdir}/inventory.txt", "0x0004 #{timefmt(Time.now)} lolwut /CN=badnode", mode: 'a')
+        expect(logger).to receive(:err).with(/Invalid not_after time found in inventory.txt line/)
+        expect(subject.parse_inventory_file("#{tmpdir}/inventory.txt", logger)).to eq([correct, true])
+      end
+    end
+
+    it 'handles an inventory.txt line with an invalid certname designation' do 
+      Dir.mktmpdir do |tmpdir|
+        write_inventory(tmpdir, inventory)
+        File.write("#{tmpdir}/inventory.txt", "0x0004 #{timefmt(Time.now)} #{timefmt(Time.now)} lolwut", mode: 'a')
+        expect(logger).to receive(:err).with(/Invalid certname found in inventory.txt line/)
+        expect(subject.parse_inventory_file("#{tmpdir}/inventory.txt", logger)).to eq([correct, true])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a module for parsing the inventory.txt file. This will handle any errors found in the file, and return a hash with certname as the key and the rest of the info has another hash.  Because the inventory will likely have old entries for a given certname, this records the serials for the old certnames, but the serial value will be the latest cert found.

Also fixes a couple issues found, mostly around spec files not getting cleaned up due to the way some of the tests were written.