### PR TITLE
(PE-34952) Add delete action with --expired flag

### DIFF
--- a/lib/puppetserver/ca/action/delete.rb
+++ b/lib/puppetserver/ca/action/delete.rb
@@ -1,0 +1,187 @@
+require 'openssl'
+require 'optparse'
+require 'time'
+require 'puppetserver/ca/certificate_authority'
+require 'puppetserver/ca/config/puppet'
+require 'puppetserver/ca/errors'
+require 'puppetserver/ca/utils/cli_parsing'
+require 'puppetserver/ca/utils/file_system'
+require 'puppetserver/ca/utils/inventory'
+require 'puppetserver/ca/x509_loader'
+
+module Puppetserver
+  module Ca
+    module Action
+      class Delete
+
+        include Puppetserver::Ca::Utils
+
+        CERTNAME_BLOCKLIST = %w{--config --expired --revoked --all}
+
+        SUMMARY = 'Delete certificate(s)'
+        BANNER = <<-BANNER
+Usage:
+  puppetserver ca delete [--help]
+  puppetserver ca delete [--config CONF] [--expired] [--revoked]
+                         [--certname NAME[,NAME]] [--all]
+
+Description:
+  Deletes signed certificates from disk. Once a certificate is
+  signed and delivered to a node, it no longer necessarily needs
+  to be stored on disk.
+
+Options:
+BANNER
+
+        def initialize(logger)
+          @logger = logger
+        end
+
+        def self.parser(parsed = {})
+          OptionParser.new do |opts|
+            opts.banner = BANNER
+            opts.on('--help', 'Display this command-specific help output') do |help|
+              parsed['help'] = true
+            end
+            opts.on('--config CONF', 'Path to puppet.conf') do |conf|
+              parsed['config'] = conf
+            end
+            opts.on('--expired', 'Delete expired signed certificates') do |expired|
+              parsed['expired'] = true
+            end
+            opts.on('--revoked', 'Delete signed certificates that have already been revoked') do |revoked|
+              parsed['revoked'] = true
+            end
+            opts.on('--certname NAME[,NAME]', Array,
+              'One or more comma-separated certnames for which to delete signed certificates') do |certs|
+              parsed['certname'] = [certs].flatten
+            end
+            opts.on('--all', 'Delete all signed certificates on disk') do |all|
+              parsed['all'] = true
+            end
+          end
+        end
+
+        def parse(args)
+          results = {}
+          parser = self.class.parser(results)
+
+          errors = CliParsing.parse_with_errors(parser, args)
+
+          if results['certname']
+            results['certname'].each do |certname|
+              if CERTNAME_BLOCKLIST.include?(certname)
+                errors << "    Cannot manage cert named `#{certname}` from "+
+                          "the CLI. If needed, use the HTTP API directly."
+              end
+            end
+          end
+
+          unless results['help'] || results['expired'] || results['revoked'] || results['certname'] || results['all']
+            errors << '  Must pass one of the valid flags to determine which certs to delete'
+          end
+
+          errors_were_handled = Errors.handle_with_usage(@logger, errors, parser.help)
+
+          exit_code = errors_were_handled ? 1 : nil
+          return results, exit_code
+        end
+
+        def run(args)
+          config = args['config']
+
+          # Validate the config path
+          if config
+            errors = FileSystem.validate_file_paths(config)
+            return 1 if Errors.handle_with_usage(@logger, errors)
+          end
+
+          # Validate puppet config setting
+          puppet = Config::Puppet.parse(config, @logger)
+          settings = puppet.settings
+          return 1 if Errors.handle_with_usage(@logger, puppet.errors)
+
+          # Validate that we are offline
+          return 1 if HttpClient.check_server_online(settings, @logger)
+
+          # Perform the desired action, keeping track if any errors occurred
+          errored = false
+          deleted_count = 0
+          inventory_file_path = File.join(settings[:cadir], 'inventory.txt')
+
+          if args['expired']
+            # Delete expired certs found in inventory first since this is cheaper.
+            # Then, look for any certs not in the inventory, check if they
+            # are expired, then delete those.
+            inventory, err = Inventory.parse_inventory_file(inventory_file_path, @logger)
+            errored ||= err
+            expired_in_inventory = inventory.select { |k,v| v[:not_after] < Time.now }.map(&:first)
+            count, err = delete_certs(settings[:cadir], expired_in_inventory)
+            deleted_count += count
+            errored ||= err
+            other_certs_to_check = find_certs_not_in_inventory(settings[:cadir], inventory.map(&:first))
+            count, err = delete_expired_certs(settings[:cadir], other_certs_to_check)
+            deleted_count += count
+            errored ||= err
+          end
+
+          plural = deleted_count == 1 ? "" : "s"
+          @logger.inform("#{deleted_count} certificate#{plural} deleted.")
+          # If encountered non-fatal errors (an invalid entry in inventory.txt, cert not existing on disk)
+          # return 24. Returning 1 should be for fatal errors where we could not do any part of the action.
+          return errored ? 24 : 0
+        end
+
+        def find_certs_not_in_inventory(cadir, inventory_certnames)
+          all_cert_files = Dir.glob("#{cadir}/signed/*.pem").map { |f| File.basename(f, '.pem') }
+          all_cert_files - inventory_certnames
+        end
+
+        def delete_certs(cadir, certnames)
+          deleted = 0
+          errored = false
+          certnames.each do |cert|
+            path = "#{cadir}/signed/#{cert}.pem"
+            if File.exist?(path)
+              @logger.inform("Deleting certificate at #{path}")
+              File.delete(path)
+              deleted += 1
+            else
+              @logger.err("Could not find certificate file at #{path}")
+              errored = true
+            end
+          end
+          [deleted, errored]
+        end
+
+        def delete_expired_certs(cadir, certnames)
+          deleted = 0
+          errored = false
+          files = certnames.map { |c| "#{cadir}/signed/#{c}.pem" }
+          files.each do |f|
+            # Shouldn't really be possible since we look for certs on disk
+            # before calling this function, but just in case.
+            unless File.exist?(f)
+              @logger.err("Could not find certificate file at #{f}")
+              errored = true
+              next
+            end
+            begin
+              cert = OpenSSL::X509::Certificate.new(File.read(f))
+            rescue OpenSSL::X509::CertificateError
+              @logger.err("Error reading certificate at #{f}")
+              errored = true
+              next
+            end
+            if cert.not_after < Time.now
+              @logger.inform("Deleting certificate at #{f}")
+              File.delete(f)
+              deleted += 1
+            end
+          end
+          [deleted, errored]
+        end
+      end
+    end
+  end
+end

--- a/lib/puppetserver/ca/cli.rb
+++ b/lib/puppetserver/ca/cli.rb
@@ -1,6 +1,7 @@
 require 'optparse'
 
 require 'puppetserver/ca/action/clean'
+require 'puppetserver/ca/action/delete'
 require 'puppetserver/ca/action/generate'
 require 'puppetserver/ca/action/import'
 require 'puppetserver/ca/action/enable'
@@ -36,6 +37,7 @@ BANNER
 
       MAINT_ACTIONS = {
         'clean'    => Action::Clean,
+        'delete'   => Action::Delete,
         'generate' => Action::Generate,
         'list'     => Action::List,
         'revoke'   => Action::Revoke,

--- a/spec/puppetserver/ca/action/delete_spec.rb
+++ b/spec/puppetserver/ca/action/delete_spec.rb
@@ -1,0 +1,153 @@
+require 'spec_helper'
+require 'utils/http'
+require 'utils/ssl'
+require 'openssl'
+require 'puppetserver/ca/action/delete'
+require 'puppetserver/ca/logger'
+
+RSpec.describe Puppetserver::Ca::Action::Delete do
+  include Utils::SSL
+
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+  let(:logger) { Puppetserver::Ca::Logger.new(:info, stdout, stderr) }
+
+  subject { Puppetserver::Ca::Action::Delete.new(logger) }
+
+  describe 'parse' do
+    it 'takes a single certname' do
+      result, maybe_code = subject.parse(['--certname', 'foo.example.com'])
+      expect(maybe_code).to eq(nil)
+      expect(result['certname']).to eq(['foo.example.com'])
+    end
+
+    it 'takes a comma separated list of certnames' do
+      result, maybe_code = subject.parse(['--certname', 'foo,bar'])
+      expect(maybe_code).to eq(nil)
+      expect(result['certname']).to eq(['foo', 'bar'])
+    end
+
+    it 'takes a custom puppet.conf location' do
+      result, maybe_code = subject.parse(['--certname', 'foo',
+                                          '--config', '/dev/tcp/example.com'])
+      expect(maybe_code).to be(nil)
+      expect(result['config']).to eq('/dev/tcp/example.com')
+    end
+  end
+
+  describe 'validation' do
+    it 'cannot revoke certs with the names of flags' do
+      result, code = subject.parse(['--certname', '--config'])
+      expect(code).to eq(1)
+      expect(stderr.string).to include('Cannot manage cert named `--config`')
+      expect(result['certname']).to eq(['--config'])
+    end
+
+    it 'must pass one of the flags to determine the action' do
+      result, code = subject.parse([])
+      expect(code).to eq(1)
+      expect(stderr.string).to include('Must pass one of the valid flags')
+    end
+  end
+
+  def timefmt(time)
+    time.utc.strftime("%Y-%m-%dT%H:%M:%SUTC")
+  end
+
+  def prepare_certs_and_inventory(cadir)
+    FileUtils.mkdir_p "#{cadir}/signed"
+    # Foo expires now, Bar expires far in the future, Baz is expired and not present in inventory
+    # Include a line for an old Bar cert to ensure we aren't deleting it and only acting based off
+    # the newest entry for a cert
+    key = OpenSSL::PKey::RSA.new(512)
+    not_before_unexpired = Time.now - 1
+    not_after_unexpired = Time.now + 360000
+    not_before_expired = Time.now - 100
+    not_after_expired = Time.now - 1
+    File.write("#{cadir}/signed/foo.pem", create_cert(key, 'foo', nil, nil, not_before_expired, not_after_expired, 1))
+    File.write("#{cadir}/signed/bar.pem", create_cert(key, 'bar', nil, nil, not_before_unexpired, not_after_unexpired, 3))
+    File.write("#{cadir}/signed/baz.pem", create_cert(key, 'baz', nil, nil, not_before_expired, not_after_expired, 4))
+    inventory = <<~INV
+      0x0001 #{timefmt(not_before_expired)} #{timefmt(not_after_expired)} /CN=foo
+      0x0002 #{timefmt(not_before_expired)} #{timefmt(not_after_expired)} /CN=bar
+      0x0003 #{timefmt(not_before_unexpired)} #{timefmt(not_after_unexpired)} /CN=bar
+
+    INV
+    File.write("#{cadir}/inventory.txt", inventory)
+  end
+
+  context 'running the action' do
+    let(:connection) { double }
+    let(:online) { Utils::Http::Result.new('200', 'running') }
+    let(:offline) { Utils::Http::Result.new('503', 'offline') }
+    before(:each) do
+      allow_any_instance_of(Puppetserver::Ca::Utils::HttpClient).
+        to receive(:with_connection).and_yield(connection)
+      allow_any_instance_of(Puppetserver::Ca::Utils::HttpClient).
+        to receive(:make_store)
+    end
+
+    describe 'common to all actionable flags' do
+      it 'errors when validating path to puppet.conf' do
+        code = subject.run({'config' => 'fake/puppet.conf'})
+        expect(code).to eq(1)
+        expect(stderr.string).to eq("Error:\nCould not read file 'fake/puppet.conf'\n")
+      end
+
+      it 'errors when puppetserver is still online' do
+        allow(connection).to receive(:get).and_return(online)
+        code = subject.run({'expired' => true})
+        expect(code).to eq(1)
+        expect(stderr.string).to eq("Puppetserver service is running. Please stop it before attempting to run this command.\n")
+      end
+    end
+
+    describe '--expired' do
+      before(:each) { allow(connection).to receive(:get).and_return(offline) }
+
+      it 'clears the two expired certs and leaves the other one alone' do
+        Dir.mktmpdir do |tmpdir|
+          with_temp_dirs tmpdir do |config|
+            cadir = "#{tmpdir}/ca"
+            prepare_certs_and_inventory(cadir)
+            code = subject.run({'config' => config, 'expired' => true})
+            expect(code).to eq(0)
+            expect(stdout.string).to match(/2 certificates deleted./)
+            expect(File.exist?("#{cadir}/signed/foo.pem")).to eq(false)
+            expect(File.exist?("#{cadir}/signed/bar.pem")).to eq(true)
+            expect(File.exist?("#{cadir}/signed/baz.pem")).to eq(false)
+          end
+        end
+      end
+
+      it 'handles one of the certs from inventory.txt being missing' do
+        Dir.mktmpdir do |tmpdir|
+          with_temp_dirs tmpdir do |config|
+            cadir = "#{tmpdir}/ca"
+            prepare_certs_and_inventory(cadir)
+            FileUtils.rm_f("#{cadir}/signed/foo.pem")
+            code = subject.run({'config' => config, 'expired' => true})
+            expect(code).to eq(24)
+            expect(stderr.string).to match(/Could not find certificate file at #{cadir}\/signed\/foo.pem/)
+            expect(stdout.string).to match(/1 certificate deleted./)
+          end
+        end
+      end
+
+      it 'handles a cert on disk not in the inventory file being a bad cert file' do
+        Dir.mktmpdir do |tmpdir|
+          with_temp_dirs tmpdir do |config|
+            cadir = "#{tmpdir}/ca"
+            prepare_certs_and_inventory(cadir)
+            File.write("#{cadir}/signed/baz.pem", "badcert")
+            code = subject.run({'config' => config, 'expired' => true})
+            expect(code).to eq(24)
+            expect(stderr.string).to match(/Error reading certificate at #{cadir}\/signed\/baz.pem/)
+            expect(stdout.string).to match(/1 certificate deleted./)
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/utils/ssl.rb
+++ b/spec/utils/ssl.rb
@@ -5,7 +5,7 @@ require 'puppetserver/ca/utils/config'
 module Utils
   module SSL
 
-    def create_cert(subject_key, name, signer_key = nil, signer_cert = nil)
+    def create_cert(subject_key, name, signer_key = nil, signer_cert = nil, not_before = Time.now - 1, not_after = Time.now + 360000, serial = rand(2**128))
       cert = OpenSSL::X509::Certificate.new
 
       signer_cert ||= cert
@@ -15,9 +15,9 @@ module Utils
       cert.subject = OpenSSL::X509::Name.parse("/CN=#{name}")
       cert.issuer = signer_cert.subject
       cert.version = 2
-      cert.serial = rand(2**128)
-      cert.not_before = Time.now - 1
-      cert.not_after = Time.now + 360000
+      cert.serial = serial
+      cert.not_before = not_before
+      cert.not_after = not_after
       ef = OpenSSL::X509::ExtensionFactory.new
       ef.issuer_certificate = signer_cert
       ef.subject_certificate = cert


### PR DESCRIPTION
This adds the `puppetserver ca delete` action, which deletes signed certs on disk without revoking them. While all the flags are defined here, only --expired is implemented so far (maybe not ideal, but the others are coming soon). This searches the inventory file for any expired certs, deletes them, then finds any certs that are not in the inventory file, checks if they are expired, and deletes those.