### PR TITLE
(PE-34952) Add --revoked action

### DIFF
--- a/lib/puppetserver/ca/action/delete.rb
+++ b/lib/puppetserver/ca/action/delete.rb
@@ -13,7 +13,6 @@ module Puppetserver
   module Ca
     module Action
       class Delete
-
         include Puppetserver::Ca::Utils
 
         CERTNAME_BLOCKLIST = %w{--config --expired --revoked --all}
@@ -107,7 +106,70 @@ BANNER
           # Perform the desired action, keeping track if any errors occurred
           errored = false
           deleted_count = 0
-          inventory_file_path = File.join(settings[:cadir], 'inventory.txt')
+          cadir = settings[:cadir]
+          inventory_file_path = File.join(cadir, 'inventory.txt')
+
+          # Because --revoke has a potentially fatal error it can throw,
+          # process it first.
+          if args['revoked']
+            loader = X509Loader.new(settings[:cacert], settings[:cakey], settings[:cacrl])
+            verified_crls = loader.crls.select { |crl| crl.verify(loader.key) }
+            unless verified_crls.length == 1
+              @logger.err("Could not identify Puppet's CRL. Aborting delete action.")
+              return 1
+            end
+            crl = verified_crls.first
+
+            # First, search the inventory for the revoked serial. 
+            # If it matches the current serial for the cert, delete the cert.
+            # If it is an old serial for the certname, verify the file on disk
+            #   is not the serial that was revoked, and then ignore it. If the
+            #   file on disk does match that serial, delete it.
+            # If it isn't in the inventory, fall back to searching every cert on
+            #   disk for the given serial.
+            inventory, err = Inventory.parse_inventory_file(inventory_file_path, @logger)
+            revoked_serials = crl.revoked.map { |r| r.serial.to_i }
+            to_delete = []
+            revoked_serials.each do |revoked_serial|
+              current_serial = inventory.find { |k,v| v[:serial] == revoked_serial }
+              old_serial = inventory.find { |k,v| v[:old_serials].include?(revoked_serial) }
+              if current_serial
+                @logger.debug("#{revoked_serial} is the current serial for #{current_serial.first}")
+                to_delete << current_serial.first
+              elsif old_serial
+                @logger.debug("#{revoked_serial} appears to be an old serial for #{old_serial.first}. Verifying cert on disk is not the revoked serial.")
+                begin
+                  serial = get_cert_serial("#{cadir}/signed/#{old_serial.first}.pem")
+                  # This should never happen unless someone has messed with
+                  # the inventory.txt file or replaced the cert on disk with
+                  # an old one.
+                  to_delete << old_serial.first if serial == revoked_serial
+                rescue Exception => e
+                  @logger.err("Error reading serial from certificate for #{old_serial.first} with exception #{e}")
+                  errored = true
+                end
+              else
+                @logger.debug("Could not find #{revoked_serial} in inventory.txt. Searching certs on disk for this serial.")
+                begin
+                  certname = find_cert_with_serial(cadir, revoked_serial)
+                  if certname
+                    to_delete << certname
+                  else
+                    @logger.err("Could not find serial #{revoked_serial} in inventory.txt or in any certificate file currently on disk.")
+                    errored = true
+                  end
+                rescue Exception => e
+                  @logger.err("Error reading serial from certificates when trying to find certificate with serial #{revoked_serial} with exception #{e}")
+                  errored = true
+                end
+              end
+            end
+            # Because the CRL will likely contain certs that no longer exist on disk,
+            # don't show an error if we can't find the file.
+            count, err = delete_certs(cadir, to_delete, false)
+            errored ||= err
+            deleted_count += count
+          end
 
           if args['expired']
             # Delete expired certs found in inventory first since this is cheaper.
@@ -116,17 +178,17 @@ BANNER
             inventory, err = Inventory.parse_inventory_file(inventory_file_path, @logger)
             errored ||= err
             expired_in_inventory = inventory.select { |k,v| v[:not_after] < Time.now }.map(&:first)
-            count, err = delete_certs(settings[:cadir], expired_in_inventory)
+            count, err = delete_certs(cadir, expired_in_inventory)
             deleted_count += count
             errored ||= err
-            other_certs_to_check = find_certs_not_in_inventory(settings[:cadir], inventory.map(&:first))
-            count, err = delete_expired_certs(settings[:cadir], other_certs_to_check)
+            other_certs_to_check = find_certs_not_in_inventory(cadir, inventory.map(&:first))
+            count, err = delete_expired_certs(cadir, other_certs_to_check)
             deleted_count += count
             errored ||= err
           end
 
           if args['certname']
-            count, errored = delete_certs(settings[:cadir], args['certname'])
+            count, errored = delete_certs(cadir, args['certname'])
             deleted_count += count
           end
 
@@ -142,7 +204,7 @@ BANNER
           all_cert_files - inventory_certnames
         end
 
-        def delete_certs(cadir, certnames)
+        def delete_certs(cadir, certnames, error_on_not_found = true)
           deleted = 0
           errored = false
           certnames.each do |cert|
@@ -152,8 +214,10 @@ BANNER
               File.delete(path)
               deleted += 1
             else
-              @logger.err("Could not find certificate file at #{path}")
-              errored = true
+              if error_on_not_found
+                @logger.err("Could not find certificate file at #{path}")
+                errored = true
+              end
             end
           end
           [deleted, errored]
@@ -185,6 +249,24 @@ BANNER
             end
           end
           [deleted, errored]
+        end
+
+        def get_cert_serial(file)
+          cert = OpenSSL::X509::Certificate.new(File.read(file))
+          cert.serial.to_i
+        end
+
+        def find_cert_with_serial(cadir, serial)
+          files = Dir.glob("#{cadir}/signed/*.pem")
+          files.each do |f|
+            begin
+              s = get_cert_serial(f)
+              return File.basename(f)[0...-4] if s == serial # Remove .pem
+            rescue Exception => e
+              @logger.debug("Error reading certificate at #{f} with exception #{e}. Skipping this file.")
+            end
+          end
+          return nil
         end
       end
     end

--- a/spec/puppetserver/ca/local_certificate_authority_spec.rb
+++ b/spec/puppetserver/ca/local_certificate_authority_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe Puppetserver::Ca::LocalCertificateAuthority do
       }
 
       before(:each) do
-        allow(File).to receive(:exist?).with(/bundle\.pem/).and_return(true)
-        allow(File).to receive(:exist?).with(/key\.pem/).and_return(true)
-        allow(File).to receive(:exist?).with(/chain\.pem/).and_return(true)
+        allow(File).to receive(:exist?).with(/ca_crt\.pem/).and_return(true)
+        allow(File).to receive(:exist?).with(/ca_key\.pem/).and_return(true)
+        allow(File).to receive(:exist?).with(/ca_crl\.pem/).and_return(true)
         allow(File).to receive(:exist?).with(/serial/).and_return(false)
         allow(File).to receive(:exist?).with(/public_keys/).and_return(false)
         allow(File).to receive(:exist?).with(/private_keys/).and_return(false)

--- a/spec/utils/ssl.rb
+++ b/spec/utils/ssl.rb
@@ -151,9 +151,9 @@ module Utils
       FileUtils.mkdir_p Puppetserver::Ca::Utils::Config.default_ssldir(confdir)
       FileUtils.mkdir_p Puppetserver::Ca::Utils::Config.new_default_cadir(confdir)
 
-      bundle_file = File.join(fixtures_dir, 'bundle.pem')
-      key_file = File.join(fixtures_dir, 'key.pem')
-      chain_file = File.join(fixtures_dir, 'chain.pem')
+      bundle_file = File.join(fixtures_dir, 'ca_crt.pem')
+      key_file = File.join(fixtures_dir, 'ca_key.pem')
+      chain_file = File.join(fixtures_dir, 'ca_crl.pem')
       config_file = File.join(fixtures_dir, 'puppet.conf')
 
       File.open(config_file, 'w') do |f|
@@ -201,9 +201,9 @@ module Utils
       FileUtils.mkdir_p ssl_dir
       FileUtils.mkdir_p "#{ca_dir}/signed"
 
-      bundle_file = File.join(ca_dir, 'bundle.pem')
-      key_file = File.join(ca_dir, 'key.pem')
-      chain_file = File.join(ca_dir, 'chain.pem')
+      bundle_file = File.join(ca_dir, 'ca_crt.pem')
+      key_file = File.join(ca_dir, 'ca_key.pem')
+      chain_file = File.join(ca_dir, 'ca_crl.pem')
       config_file = File.join(ca_dir, 'puppet.conf')
 
       File.open(config_file, 'w') do |f|


### PR DESCRIPTION
This inspects the CRL for a list of revoked serials. It then searches inventory.txt for those serials. If the given serial is the latest one for the particular certname, it puts it on a list for deletion (although it may in fact already be deleted). If it's an old serial for a particular certname, it verifies the cert on disk is a later serial. If for some reason it isn't, it removes the cert on disk as it matches the serial in the CRL. If it isn't in inventory.txt at all, it searches all certs on disk for the given serial. If it's found, it adds that cert to the list for deletion. It then deletes all relevant certs that exist.