### PR TITLE
(PE-35382) Add --all action

### DIFF
--- a/lib/puppetserver/ca/action/delete.rb
+++ b/lib/puppetserver/ca/action/delete.rb
@@ -273,7 +273,7 @@ BANNER
           files.each do |f|
             begin
               s = get_cert_serial(f)
-              return File.basename(f)[0...-4] if s == serial # Remove .pem
+              return File.basename(f, '.pem') if s == serial # Remove .pem
             rescue Exception => e
               @logger.debug("Error reading certificate at #{f} with exception #{e}. Skipping this file.")
             end

--- a/lib/puppetserver/ca/action/delete.rb
+++ b/lib/puppetserver/ca/action/delete.rb
@@ -80,6 +80,10 @@ BANNER
             errors << '  Must pass one of the valid flags to determine which certs to delete'
           end
 
+          if results['all'] && (results['expired'] || results['revoked'] || results['certname'])
+            errors << '  The --all flag must not be used with --expired, --revoked, or --certname'
+          end
+
           errors_were_handled = Errors.handle_with_usage(@logger, errors, parser.help)
 
           exit_code = errors_were_handled ? 1 : nil
@@ -190,6 +194,12 @@ BANNER
           if args['certname']
             count, errored = delete_certs(cadir, args['certname'])
             deleted_count += count
+          end
+
+          if args['all']
+            certnames = Dir.glob("#{cadir}/signed/*.pem").map{ |c| File.basename(c, '.pem') }
+            # Since we don't run this with any other flags, we can set these variables directly
+            deleted_count, errored = delete_certs(cadir, certnames)
           end
 
           plural = deleted_count == 1 ? "" : "s"

--- a/lib/puppetserver/ca/action/delete.rb
+++ b/lib/puppetserver/ca/action/delete.rb
@@ -182,7 +182,9 @@ BANNER
             inventory, err = Inventory.parse_inventory_file(inventory_file_path, @logger)
             errored ||= err
             expired_in_inventory = inventory.select { |k,v| v[:not_after] < Time.now }.map(&:first)
-            count, err = delete_certs(cadir, expired_in_inventory)
+            # Don't print errors if the cert is not found, since the inventory
+            # file can contain old entries that have already been deleted.
+            count, err = delete_certs(cadir, expired_in_inventory, false)
             deleted_count += count
             errored ||= err
             other_certs_to_check = find_certs_not_in_inventory(cadir, inventory.map(&:first))

--- a/lib/puppetserver/ca/action/delete.rb
+++ b/lib/puppetserver/ca/action/delete.rb
@@ -17,7 +17,7 @@ module Puppetserver
 
         CERTNAME_BLOCKLIST = %w{--config --expired --revoked --all}
 
-        SUMMARY = 'Delete certificate(s)'
+        SUMMARY = 'Delete signed certificate(s) from disk'
         BANNER = <<-BANNER
 Usage:
   puppetserver ca delete [--help]

--- a/lib/puppetserver/ca/cli.rb
+++ b/lib/puppetserver/ca/cli.rb
@@ -28,6 +28,7 @@ Puppet Server's built-in Certificate Authority
 BANNER
 
       ADMIN_ACTIONS = {
+        'delete'   => Action::Delete,
         'import'   => Action::Import,
         'setup'    => Action::Setup,
         'enable'   => Action::Enable,
@@ -37,7 +38,6 @@ BANNER
 
       MAINT_ACTIONS = {
         'clean'    => Action::Clean,
-        'delete'   => Action::Delete,
         'generate' => Action::Generate,
         'list'     => Action::List,
         'revoke'   => Action::Revoke,

--- a/spec/puppetserver/ca/action/delete_spec.rb
+++ b/spec/puppetserver/ca/action/delete_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe Puppetserver::Ca::Action::Delete do
             prepare_certs_and_inventory(cadir)
             FileUtils.rm_f("#{cadir}/signed/nodeA.pem")
             code = subject.run({'config' => config, 'expired' => true})
-            expect(code).to eq(24)
-            expect(stderr.string).to match(/Could not find certificate file at #{cadir}\/signed\/nodeA.pem/)
+            expect(code).to eq(0)
+            expect(stderr.string).not_to match(/Could not find certificate file at #{cadir}\/signed\/nodeA.pem/)
             expect(stdout.string).to match(/1 certificate deleted./)
           end
         end


### PR DESCRIPTION
This deletes all certs in the signed directory, and must be used by itself.

Additionally, this tweaks the behavior of puppetserver ca delete --expired to not print an error when a cert listed in the inventory is not found on disk, since this will happen when you run the command multiple times and we don't really want people messing with inventory.txt manually to get rid of this error.