### PR TITLE
Fix duplicate attribute error with OpenSSL 3.1+

### DIFF
--- a/spec/puppetserver/ca/action/generate_spec.rb
+++ b/spec/puppetserver/ca/action/generate_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe Puppetserver::Ca::Action::Generate do
       end
 
       it "return nil for csr if attribute name provided is private" do
-        csr_attributes['custom_attributes'].merge!({'extReq' => "ulla"})
+        csr_attributes['custom_attributes'].merge!({'msExtReq' => "ulla"})
         allow(YAML).to receive(:load_file).and_return(csr_attributes)
         _, csr = subject.generate_key_csr('foo', settings, OpenSSL::Digest::SHA256.new)
         expect(csr).to eq(nil)


### PR DESCRIPTION
This fixes a test suite error when building with OpenSSL 3.1 or later:

```
1) Puppetserver::Ca::Action::Generate downloading with a csr_attributes file return nil for csr if attribute name provided is private
   Failure/Error: _, csr = subject.generate_key_csr('foo', settings, OpenSSL::Digest::SHA256.new)

   OpenSSL::X509::RequestError:
     duplicate attribute
   # /usr/share/rubygems-integration/all/gems/puppetserver-ca-2.4.0/lib/puppetserver/ca/host.rb:155:in `add_attribute'
   # /usr/share/rubygems-integration/all/gems/puppetserver-ca-2.4.0/lib/puppetserver/ca/host.rb:155:in `add_csr_extensions'
   # /usr/share/rubygems-integration/all/gems/puppetserver-ca-2.4.0/lib/puppetserver/ca/host.rb:89:in `create_csr'
   # /usr/share/rubygems-integration/all/gems/puppetserver-ca-2.4.0/lib/puppetserver/ca/action/generate.rb:275:in `generate_key_csr'
   # ./spec/puppetserver/ca/action/generate_spec.rb:294:in `block (4 levels) in <top (required)>'
```

By using another private x509 attribute which is not already defined in the custom_attributes file, the test case passes.