### PR TITLE
(SERVER-2691) configurable root ca name

### DIFF
--- a/lib/puppetserver/ca/action/setup.rb
+++ b/lib/puppetserver/ca/action/setup.rb
@@ -19,7 +19,7 @@ module Puppetserver
 Usage:
   puppetserver ca setup [--help]
   puppetserver ca setup [--config PATH] [--subject-alt-names NAME[,NAME]]
-                           [--certname NAME] [--ca-name NAME]
+                           [--certname NAME] [--ca-name NAME] [--root-ca-name NAME]
 
 Description:
   Setup a root and intermediate signing CA for Puppet Server
@@ -51,6 +51,7 @@ BANNER
           settings_overrides = {}
           settings_overrides[:certname] = input['certname'] unless input['certname'].empty?
           settings_overrides[:ca_name] = input['ca-name'] unless input['ca-name'].empty?
+          settings_overrides[:root_ca_name] = input['root-ca-name'] unless input['root-ca-name'].empty?
           # Since puppet expects the key to be called 'dns_alt_names', we need to use that here
           # to ensure that the overriding works correctly.
           settings_overrides[:dns_alt_names] = input['subject-alt-names'] unless input['subject-alt-names'].empty?
@@ -153,6 +154,7 @@ ERR
         def self.parser(parsed = {})
           parsed['subject-alt-names'] = ''
           parsed['ca-name'] = ''
+          parsed['root-ca-name'] = ''
           parsed['certname'] = ''
           OptionParser.new do |opts|
             opts.banner = BANNER
@@ -169,6 +171,10 @@ ERR
             opts.on('--ca-name NAME',
                     'Common name to use for the CA signing cert') do |name|
               parsed['ca-name'] = name
+            end
+            opts.on('--root-ca-name NAME',
+                    'Common name to use for the self-signed Root CA cert') do |name|
+              parsed['root-ca-name'] = name
             end
             opts.on('--certname NAME',
                     'Common name to use for the server cert') do |name|

--- a/spec/puppetserver/ca/config/puppet_spec.rb
+++ b/spec/puppetserver/ca/config/puppet_spec.rb
@@ -55,6 +55,21 @@ RSpec.describe 'Puppetserver::Ca::Config::Puppet' do
     expect(parsed).to include({ca: {cadir: '/var/www/ca'}})
   end
 
+  it 'correctly parses values with spaces and comments' do
+    parsed = subject.parse_text(<<-INI)
+    [master]
+      ca_name = Some Other CA
+      root_ca_name = Another Root CA # comment
+      cadir = /some/where discard/this # here
+    INI
+
+    expect(parsed[:master]).to include({
+      ca_name: 'Some Other CA',
+      root_ca_name: 'Another Root CA',
+      cadir: '/some/where'
+    })
+  end
+
   it 'resolves dependent settings properly' do
     Dir.mktmpdir do |tmpdir|
       puppet_conf = File.join(tmpdir, 'puppet.conf')

--- a/spec/shared_examples/setup.rb
+++ b/spec/shared_examples/setup.rb
@@ -9,7 +9,7 @@ end
 def default_config(conf, bundle, key, chain)
   shared_flags = {'config' => conf, 'subject-alt-names' => '', 'certname' => 'foocert'}
   import_flags = {'cert-bundle' => bundle, 'private-key' => key, 'crl-chain' => chain}
-  importing ? shared_flags.merge(import_flags) : shared_flags.merge({'ca-name' => ''})
+  importing ? shared_flags.merge(import_flags) : shared_flags.merge({'ca-name' => '', 'root-ca-name' => ''})
 end
 
 def flags_without_sans(*args)


### PR DESCRIPTION
Adds command line parameter for the root ca name, and supports spaces in the ca_name and root_ca_name values when parsed from the config file.