### PR TITLE
(PE-37501) Use bulk signing endpoints when possible

### DIFF
--- a/lib/puppetserver/ca/utils/http_client.rb
+++ b/lib/puppetserver/ca/utils/http_client.rb
@@ -130,6 +130,19 @@ module Puppetserver
             Result.new(result.code, result.body)
           end
 
+          def post(body, url_override = nil, header_overrides = {})
+            url = url_override || @url
+            headers = @default_headers.merge(header_overrides)
+
+            @logger.debug("Making a POST request at #{url.full_url}")
+
+            request = Net::HTTP::Post.new(url.to_uri, headers)
+            request.body = body
+            result = @conn.request(request)
+
+            Result.new(result.code, result.body)
+          end
+
           def delete(url_override = nil, header_overrides = {})
             url = url_override || @url
             headers = @default_headers.merge(header_overrides)
@@ -151,7 +164,7 @@ module Puppetserver
                          :resource_type, :resource_name, :query) do
                 def full_url
                   url = protocol + '://' + host + ':' + port + '/' +
-                        [endpoint, version, resource_type, resource_name].join('/')
+                        [endpoint, version, resource_type, resource_name].compact.join('/')
 
                   url = url + "?" + URI.encode_www_form(query) unless query.nil? || query.empty?
                   return url

--- a/spec/puppetserver/ca/action/sign_spec.rb
+++ b/spec/puppetserver/ca/action/sign_spec.rb
@@ -1,6 +1,7 @@
 require 'puppetserver/ca/action/sign'
 require 'puppetserver/ca/cli'
 require 'puppetserver/ca/logger'
+require 'puppetserver/ca/utils/http_client'
 
 RSpec.describe 'Puppetserver::Ca::SignAction' do
   let(:err)    { StringIO.new }
@@ -64,7 +65,11 @@ RSpec.describe 'Puppetserver::Ca::SignAction' do
     let(:get_success)   { response.new('200', 'Stuff') }
     let(:not_found)     { response.new('404', 'Not Found') }
     let(:empty)         { response.new('404', '[]') }
-
+    let(:status_url)    { Puppetserver::Ca::Utils::HttpClient::URL.new('https','localhost','8140','status','v1','services') }
+    let(:bulk_sign_url) { Puppetserver::Ca::Utils::HttpClient::URL.new('https','localhost','8140','puppet-ca','v1','sign', nil, {}) }
+    let(:bulk_sign_all_url) { Puppetserver::Ca::Utils::HttpClient::URL.new('https','localhost','8140','puppet-ca','v1','sign','all', {}) }
+    let(:status_old_server) { response.new('200', '{"ca":{"service_version":"7.4.1"}}') }
+    let(:status_new_server) { response.new('200', '{"ca":{"service_version":"8.4.1"}}') }
     let(:connection) { double }
 
     before do
@@ -78,56 +83,184 @@ RSpec.describe 'Puppetserver::Ca::SignAction' do
         to receive(:load_key)
     end
 
-    it 'logs and exits with zero with successful PUT' do
-      allow(connection).to receive(:put).and_return(success)
-      exit_code = action.run({'certname' => ['foo']})
-      expect(exit_code).to eq(0)
-      expect(out.string).to include('signed certificate request for foo')
+    describe 'bulk signing available' do
+      before { allow(connection).to receive(:get).with(status_url).and_return(status_new_server) }
+
+      describe 'using --certname' do
+        it 'uses /certificate_status endpoint when specifying TTL' do
+          allow(connection).to receive(:put).with(/3600/, any_args).and_return(success)
+          exit_code = action.run({'certname' => ['foo'], 'ttl' => '1h'})
+          expect(exit_code).to eq(0)
+          expect(out.string).to include('signed certificate request for foo')
+        end
+
+        it 'uses the /sign endpoint' do
+          result = response.new('200', '{"signed":["foo","bar"],"no-csr":[],"signing-errors":[]}')
+          allow(connection).to receive(:post).with("{\"certnames\":[\"foo\", \"bar\"]}", bulk_sign_url, {}).and_return(result)
+          exit_code = action.run({'certname' => ['foo','bar']})
+          expect(exit_code).to eq(0)
+          expect(out.string).to match(/Successfully signed the following.*foo.*bar/m)
+        end
+
+        it 'handles no CSR being present' do
+          result = response.new('200', '{"signed":["foo"],"no-csr":["bar"],"signing-errors":[]}')
+          allow(connection).to receive(:post).with("{\"certnames\":[\"foo\", \"bar\"]}", bulk_sign_url, {}).and_return(result)
+          exit_code = action.run({'certname' => ['foo','bar']})
+          expect(exit_code).to eq(1)
+          expect(out.string).to match(/Successfully signed the following.*foo/m)
+          expect(err.string).to match(/No certificate request.*bar/m)
+        end
+
+        it 'handles an error signing a cert' do
+          result = response.new('200', '{"signed":["foo"],"no-csr":[],"signing-errors":["bar"]}')
+          allow(connection).to receive(:post).with("{\"certnames\":[\"foo\", \"bar\"]}", bulk_sign_url, {}).and_return(result)
+          exit_code = action.run({'certname' => ['foo','bar']})
+          expect(exit_code).to eq(1)
+          expect(out.string).to match(/Successfully signed the following.*foo/m)
+          expect(err.string).to match(/Error encountered when attempting to sign.*bar/m)
+        end
+
+        it 'handles no body in the response' do
+          result = response.new('200', nil)
+          allow(connection).to receive(:post).with("{\"certnames\":[\"foo\", \"bar\"]}", bulk_sign_url, {}).and_return(result)
+          exit_code = action.run({'certname' => ['foo','bar']})
+          expect(exit_code).to eq(1)
+          expect(err.string).to match(/Response from \/sign endpoint did not include a body/m)
+        end
+
+        it 'handles a non-JSON response' do
+          result = response.new('200', 'nu uh, not gonna sign nuthin')
+          allow(connection).to receive(:post).with("{\"certnames\":[\"foo\", \"bar\"]}", bulk_sign_url, {}).and_return(result)
+          exit_code = action.run({'certname' => ['foo','bar']})
+          expect(exit_code).to eq(1)
+          expect(err.string).to match(/Unable to parse the response from the \/sign endpoint/m)
+        end
+
+        it 'handles a non-200 response' do
+          result = response.new('404', 'Not found')
+          allow(connection).to receive(:post).with("{\"certnames\":[\"foo\", \"bar\"]}", bulk_sign_url, {}).and_return(result)
+          exit_code = action.run({'certname' => ['foo','bar']})
+          expect(exit_code).to eq(1)
+          expect(err.string).to match(/When attempting to sign certificate requests.*404.*Not found/m)
+        end
+      end
+
+      describe 'using --all' do
+        it 'uses /certificate_status endpoint when specifying TTL and --all' do
+          allow(connection).to receive(:put).with(/3600/, any_args).and_return(success)
+          allow(connection).to receive(:get).and_return(get_success)
+          allow(action).to receive(:select_pending_certs).and_return(['ulla'])
+          exit_code = action.run({'all' => true, 'ttl' => '1h'})
+          expect(exit_code).to eq(0)
+          expect(out.string).to include('signed certificate request for ulla')
+        end
+
+        it 'uses /sign/all when specifying --all' do
+          result = response.new('200', '{"signed":["foo","bar"],"no-csr":[],"signing-errors":[]}')
+          allow(connection).to receive(:post).with("{}", bulk_sign_all_url, {}).and_return(result)
+          exit_code = action.run({'all' => true})
+          expect(exit_code).to eq(0)
+          expect(out.string).to match(/Successfully signed the following.*foo.*bar/m)
+        end
+
+        it 'handles no CSRs waiting to be signed when specifying --all' do
+          result = response.new('200', '{"signed":[],"no-csr":[],"signing-errors":[]}')
+          allow(connection).to receive(:post).with("{}", bulk_sign_all_url, {}).and_return(result)
+          exit_code = action.run({'all' => true})
+          expect(exit_code).to eq(24)
+          expect(err.string).to match(/No waiting certificate requests to sign/)
+        end
+
+        it 'handles an error signing a cert' do
+          result = response.new('200', '{"signed":["foo"],"no-csr":[],"signing-errors":["bar"]}')
+          allow(connection).to receive(:post).with("{}", bulk_sign_all_url, {}).and_return(result)
+          exit_code = action.run({'all' => true})
+          expect(exit_code).to eq(1)
+          expect(out.string).to match(/Successfully signed the following.*foo/m)
+          expect(err.string).to match(/Error encountered when attempting to sign.*bar/m)
+        end
+
+        it 'handles no body in the response' do
+          result = response.new('200', nil)
+          allow(connection).to receive(:post).with("{}", bulk_sign_all_url, {}).and_return(result)
+          exit_code = action.run({'all' => true})
+          expect(exit_code).to eq(1)
+          expect(err.string).to match(/Response from \/sign\/all endpoint did not include a body/m)
+        end
+
+        it 'handles a non-JSON response' do
+          result = response.new('200', 'nu uh, not gonna sign nuthin')
+          allow(connection).to receive(:post).with("{}", bulk_sign_all_url, {}).and_return(result)
+          exit_code = action.run({'all' => true})
+          expect(exit_code).to eq(1)
+          expect(err.string).to match(/Unable to parse the response from the \/sign\/all endpoint/m)
+        end
+
+        it 'handles a non-200 response' do
+          result = response.new('404', 'Not found')
+          allow(connection).to receive(:post).with("{}", bulk_sign_all_url, {}).and_return(result)
+          exit_code = action.run({'all' => true})
+          expect(exit_code).to eq(1)
+          expect(err.string).to match(/When attempting to sign all certificate requests.*404.*Not found/m)
+        end
+      end
     end
 
-    it 'logs and exits with zero with successful PUT with a custom ttl' do
-      allow(connection).to receive(:put).with(/3600/, any_args).and_return(success)
-      exit_code = action.run({'certname' => ['foo'], 'ttl' => '1h'})
-      expect(exit_code).to eq(0)
-      expect(out.string).to include('signed certificate request for foo')
-    end
 
-    it 'fails when an invalid ttl is specified' do
-      exit_code = action.run({'certname' => ['foo'], 'ttl' => '1x'})
-      expect(exit_code).to eq(1)
-      expect(err.string).to match(/Error.* invalid ttl value/m)
-      expect(connection).to_not receive(:put)
-    end
+    describe 'bulk signing unavailable' do
+      before { allow(connection).to receive(:get).with(status_url).and_return(status_old_server) }
 
-    it 'logs and exits with zero with successful GET and PUT' do
-      allow(connection).to receive(:put).and_return(success)
-      allow(connection).to receive(:get).and_return(get_success)
-      allow(action).to receive(:select_pending_certs).and_return(['ulla'])
-      exit_code = action.run({'all' => true})
-      expect(exit_code).to eq(0)
-      expect(out.string).to include('signed certificate request for ulla')
-    end
+      it 'logs and exits with zero with successful PUT' do
+        allow(connection).to receive(:put).and_return(success)
+        exit_code = action.run({'certname' => ['foo']})
+        expect(exit_code).to eq(0)
+        expect(out.string).to include('signed certificate request for foo')
+      end
 
-    it 'fails when GET request errors' do
-      allow(connection).to receive(:get).and_return(not_found)
-      exit_code = action.run({'all' => true})
-      expect(exit_code).to eq(1)
-    end
+      it 'logs and exits with zero with successful PUT with a custom ttl' do
+        allow(connection).to receive(:put).with(/3600/, any_args).and_return(success)
+        exit_code = action.run({'certname' => ['foo'], 'ttl' => '1h'})
+        expect(exit_code).to eq(0)
+        expect(out.string).to include('signed certificate request for foo')
+      end
 
-    it 'returns 24 when no pending certs' do
-      allow_any_instance_of(Puppetserver::Ca::CertificateAuthority).
-        to receive(:get_certificate_statuses).and_return(empty)
-      exit_code = action.run({'all' => true})
-      expect(exit_code).to eq(24)
-      expect(err.string).to include('No waiting certificate requests to sign')
-    end
+      it 'fails when an invalid ttl is specified' do
+        exit_code = action.run({'certname' => ['foo'], 'ttl' => '1x'})
+        expect(exit_code).to eq(1)
+        expect(err.string).to match(/Error.* invalid ttl value/m)
+        expect(connection).to_not receive(:put)
+      end
 
-    it 'continues signing certs after failed request' do
-      allow(connection).to receive(:put).and_return(success, not_found, success)
-      exit_code = action.run({'certname' => ['foo','bar','baz']})
-      expect(exit_code).to eq(1)
-      expect(out.string).to match(/signed certificate request for foo.*signed certificate request for baz/m)
-      expect(err.string).to include('Could not find certificate request for bar')
+      it 'logs and exits with zero with successful GET and PUT' do
+        allow(connection).to receive(:put).and_return(success)
+        allow(connection).to receive(:get).and_return(get_success)
+        allow(action).to receive(:select_pending_certs).and_return(['ulla'])
+        exit_code = action.run({'all' => true})
+        expect(exit_code).to eq(0)
+        expect(out.string).to include('signed certificate request for ulla')
+      end
+
+      it 'fails when GET request errors' do
+        allow(connection).to receive(:get).and_return(not_found)
+        exit_code = action.run({'all' => true})
+        expect(exit_code).to eq(1)
+      end
+
+      it 'returns 24 when no pending certs' do
+        allow_any_instance_of(Puppetserver::Ca::CertificateAuthority).
+          to receive(:get_certificate_statuses).and_return(empty)
+        exit_code = action.run({'all' => true})
+        expect(exit_code).to eq(24)
+        expect(err.string).to include('No waiting certificate requests to sign')
+      end
+
+      it 'continues signing certs after failed request' do
+        allow(connection).to receive(:put).and_return(success, not_found, success)
+        exit_code = action.run({'certname' => ['foo','bar','baz']})
+        expect(exit_code).to eq(1)
+        expect(out.string).to match(/signed certificate request for foo.*signed certificate request for baz/m)
+        expect(err.string).to include('Could not find certificate request for bar')
+      end
     end
   end
 end


### PR DESCRIPTION
Now that we have the /sign and /sign/all endpoints, this modifies the code to use these endpoints when the server version is 8.4.0+ or newer with these endpoints. Because the endpoints don't support setting the TTL, this falls back to the /certificate_status endpoint if TTL is specified.