### PR TITLE
Stop activating Bundler in puppetserver-ca

### DIFF
--- a/exe/puppetserver-ca
+++ b/exe/puppetserver-ca
@@ -1,10 +1,5 @@
 #!/usr/bin/env ruby
 
-# This requires everything in our Gemfile, so when functionally testing
-# our debugging tools are available without having to require them
-require 'bundler/setup'
-Bundler.require(:default)
-
 require 'puppetserver/ca/cli'
 
 exit Puppetserver::Ca::Cli.run(ARGV)


### PR DESCRIPTION
This fails on current Bundler versions where require is a private method. It also makes it useless outside of a bundler context.