### PR TITLE
Drop setting value for csr.version, fixes #124

### DIFF
--- a/lib/puppetserver/ca/host.rb
+++ b/lib/puppetserver/ca/host.rb
@@ -80,7 +80,6 @@ module Puppetserver
         csr = OpenSSL::X509::Request.new
         csr.public_key = key.public_key
         csr.subject = OpenSSL::X509::Name.new([["CN", name]])
-        csr.version = 2
 
         custom_attributes = get_custom_attributes(csr_attributes_path)
         extension_requests = get_extension_requests(csr_attributes_path)


### PR DESCRIPTION
OpenSSL versions 3.4.0 and later no longer support setting a CSR version other than 1, because there are no other valid versions. Rather, it is recommended to stop specificying a CSR version altogether.

https://github.com/openssl/openssl/commit/397051a40db2d68433b842e7505e8cf3c9effb36